### PR TITLE
Fix: using `Self` in a struct with `#[pin_data]` resulted in a compilation error

### DIFF
--- a/pinned-init-macro/Cargo.lock
+++ b/pinned-init-macro/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "pinned-init-macro"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pinned-init-macro/src/pin_data.rs
+++ b/pinned-init-macro/src/pin_data.rs
@@ -94,9 +94,6 @@ pub(crate) fn pin_data(
     let args: TokenStream = args.into();
     // This proc-macro only does some pre-parsing and then delegates the actual parsing to
     // `pinned_init::__pin_data!`.
-    //
-    // In here we only collect the generics, since parsing them in declarative macros is very
-    // elaborate. We also do not need to analyse their structure, we only need to collect them.
 
     let (
         Generics {

--- a/pinned-init-macro/src/pin_data.rs
+++ b/pinned-init-macro/src/pin_data.rs
@@ -1,24 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use proc_macro2::{Punct, Spacing, TokenStream, TokenTree};
+use proc_macro2::{Group, Punct, Spacing, TokenStream, TokenTree};
+use quote::quote;
 
-pub(crate) fn pin_data(
-    args: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    let args: TokenStream = args.into();
-    let input: TokenStream = input.into();
-    // This proc-macro only does some pre-parsing and then delegates the actual parsing to
-    // `pinned_init::__pin_data!`.
-    //
-    // In here we only collect the generics, since parsing them in declarative macros is very
-    // elaborate. We also do not need to analyse their structure, we only need to collect them.
+struct Generics {
+    impl_generics: Vec<TokenTree>,
+    ty_generics: Vec<TokenTree>,
+}
 
+/// Parses the given `TokenStream` into `Generics` and the rest.
+///
+/// The generics are not present in the rest, but a where clause might remain.
+fn parse_generics(input: TokenStream) -> (Generics, Vec<TokenTree>) {
     // `impl_generics`, the declared generics with their bounds.
     let mut impl_generics = vec![];
     // Only the names of the generics, without any bounds.
     let mut ty_generics = vec![];
-    // Tokens not related to the generics e.g. the `impl` token.
+    // Tokens not related to the generics e.g. the `where` token and definition.
     let mut rest = vec![];
     // The current level of `<`.
     let mut nesting = 0;
@@ -29,16 +27,19 @@ pub(crate) fn pin_data(
         match tt.clone() {
             TokenTree::Punct(p) if p.as_char() == '<' => {
                 if nesting >= 1 {
+                    // This is inside of the generics and part of some bound.
                     impl_generics.push(tt);
                 }
                 nesting += 1;
             }
             TokenTree::Punct(p) if p.as_char() == '>' => {
+                // This is a parsing error, so we just end it here.
                 if nesting == 0 {
                     break;
                 } else {
                     nesting -= 1;
                     if nesting >= 1 {
+                        // We are still inside of the generics and part of some bound.
                         impl_generics.push(tt);
                     }
                     if nesting == 0 {
@@ -48,14 +49,19 @@ pub(crate) fn pin_data(
             }
             tt => {
                 if nesting == 1 {
+                    // Here depending on the token, it might be a generic variable name.
                     match &tt {
-                        TokenTree::Ident(i) if *i == "const" => {}
+                        // Ignore const.
+                        TokenTree::Ident(i) if i.to_string() == "const" => {}
                         TokenTree::Ident(_) if at_start => {
                             ty_generics.push(tt.clone());
+                            // We also already push the `,` token, this makes it easier to append
+                            // generics.
                             ty_generics.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
                             at_start = false;
                         }
                         TokenTree::Punct(p) if p.as_char() == ',' => at_start = true,
+                        // Lifetimes begin with `'`.
                         TokenTree::Punct(p) if p.as_char() == '\'' && at_start => {
                             ty_generics.push(tt.clone());
                         }
@@ -65,21 +71,148 @@ pub(crate) fn pin_data(
                 if nesting >= 1 {
                     impl_generics.push(tt);
                 } else if nesting == 0 {
+                    // If we haven't entered the generics yet, we still want to keep these tokens.
                     rest.push(tt);
                 }
             }
         }
     }
     rest.extend(toks);
+    (
+        Generics {
+            impl_generics,
+            ty_generics,
+        },
+        rest,
+    )
+}
+
+pub(crate) fn pin_data(
+    args: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let args: TokenStream = args.into();
+    // This proc-macro only does some pre-parsing and then delegates the actual parsing to
+    // `pinned_init::__pin_data!`.
+    //
+    // In here we only collect the generics, since parsing them in declarative macros is very
+    // elaborate. We also do not need to analyse their structure, we only need to collect them.
+
+    let (
+        Generics {
+            impl_generics,
+            ty_generics,
+        },
+        rest,
+    ) = parse_generics(input.into());
+    // The struct definition might contain the `Self` type. Since `__pin_data!` will define a new
+    // type with the same generics and bounds, this poses a problem, since `Self` will refer to the
+    // new type as opposed to this struct definition. Therefore we have to replace `Self` with the
+    // concrete name.
+
+    // Errors that occur when replacing `Self` with `struct_name`.
+    let mut errs = TokenStream::new();
+    // The name of the struct with ty_generics.
+    let struct_name = rest
+        .iter()
+        .skip_while(|tt| !matches!(tt, TokenTree::Ident(i) if i.to_string() == "struct"))
+        .nth(1)
+        .and_then(|tt| match tt {
+            TokenTree::Ident(_) => {
+                let tt = tt.clone();
+                let mut res = vec![tt];
+                if !ty_generics.is_empty() {
+                    // We add this, so it is maximally compatible with e.g. `Self::CONST` which
+                    // will be replaced by `StructName::<$generics>::CONST`.
+                    res.push(TokenTree::Punct(Punct::new(':', Spacing::Joint)));
+                    res.push(TokenTree::Punct(Punct::new(':', Spacing::Alone)));
+                    res.push(TokenTree::Punct(Punct::new('<', Spacing::Alone)));
+                    res.extend(ty_generics.iter().cloned());
+                    res.push(TokenTree::Punct(Punct::new('>', Spacing::Alone)));
+                }
+                Some(res)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            // If we did not find the name of the struct then we will use `Self` as the replacement
+            // and add a compile error to ensure it does not compile.
+            errs.extend(
+                "::core::compile_error!(\"Could not locate type name.\");"
+                    .parse::<TokenStream>()
+                    .unwrap(),
+            );
+            "Self".parse::<TokenStream>().unwrap().into_iter().collect()
+        });
+    let impl_generics = impl_generics
+        .into_iter()
+        .flat_map(|tt| replace_self_and_deny_type_defs(&struct_name, tt, &mut errs))
+        .collect::<Vec<_>>();
+    let mut rest = rest
+        .into_iter()
+        .flat_map(|tt| {
+            // We ignore top level `struct` tokens, since they would emit a compile error.
+            if matches!(&tt, TokenTree::Ident(i) if i.to_string() == "struct") {
+                vec![tt]
+            } else {
+                replace_self_and_deny_type_defs(&struct_name, tt, &mut errs)
+            }
+        })
+        .collect::<Vec<_>>();
     // This should be the body of the struct `{...}`.
     let last = rest.pop();
-    quote::quote!(::pinned_init::__pin_data! {
+    let mut quoted = quote!(::pinned_init::__pin_data! {
         parse_input:
         @args(#args),
         @sig(#(#rest)*),
         @impl_generics(#(#impl_generics)*),
         @ty_generics(#(#ty_generics)*),
         @body(#last),
-    })
-    .into()
+    });
+    quoted.extend(errs);
+    quoted.into()
+}
+
+/// Replaces `Self` with `struct_name` and errors on `enum`, `trait`, `struct` `union` and `impl`
+/// keywords.
+///
+/// The error is appended to `errs` to allow normal parsing to continue.
+fn replace_self_and_deny_type_defs(
+    struct_name: &Vec<TokenTree>,
+    tt: TokenTree,
+    errs: &mut TokenStream,
+) -> Vec<TokenTree> {
+    match tt {
+        TokenTree::Ident(ref i)
+            if i.to_string() == "enum"
+                || i.to_string() == "trait"
+                || i.to_string() == "struct"
+                || i.to_string() == "union"
+                || i.to_string() == "impl" =>
+        {
+            errs.extend(
+                format!(
+                    "::core::compile_error!(\"Cannot use `{i}` inside of struct definition with \
+                        `#[pin_data]`.\");"
+                )
+                .parse::<TokenStream>()
+                .unwrap()
+                .into_iter()
+                .map(|mut tok| {
+                    tok.set_span(tt.span());
+                    tok
+                }),
+            );
+            vec![tt]
+        }
+        TokenTree::Ident(i) if i.to_string() == "Self" => struct_name.clone(),
+        TokenTree::Literal(_) | TokenTree::Punct(_) | TokenTree::Ident(_) => vec![tt],
+        TokenTree::Group(g) => vec![TokenTree::Group(Group::new(
+            g.delimiter(),
+            g.stream()
+                .into_iter()
+                .flat_map(|tt| replace_self_and_deny_type_defs(struct_name, tt, errs))
+                .collect(),
+        ))],
+    }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -64,7 +64,7 @@
 //! - use global paths, similarly to file paths, these start with the separator: `::core::panic!()`
 //!   this ensures that the correct item is used, since users could define their own `mod core {}`
 //!   and then their own `panic!` inside to execute arbitrary code inside of our macro.
-//! - macro `unsafe` hygene: we need to ensure that we do not expand arbitrary, user-supplied
+//! - macro `unsafe` hygiene: we need to ensure that we do not expand arbitrary, user-supplied
 //!   expressions inside of an `unsafe` block in the macro, because this would allow users to do
 //!   `unsafe` operations without an associated `unsafe` block.
 //!
@@ -80,6 +80,7 @@
 //! #[pin_data]
 //! #[repr(C)]
 //! struct Bar<T> {
+//!     #[pin]
 //!     t: T,
 //!     pub x: usize,
 //! }
@@ -120,20 +121,22 @@
 //!         unsafe fn t<E>(
 //!             self,
 //!             slot: *mut T,
-//!             init: impl ::pinned_init::Init<T, E>,
+//!             // Since `t` is `#[pin]`, this is `PinInit`.
+//!             init: impl ::pinned_init::PinInit<T, E>,
 //!         ) -> ::core::result::Result<(), E> {
-//!             unsafe { ::pinned_init::Init::__init(init, slot) }
+//!             unsafe { ::pinned_init::PinInit::__pinned_init(init, slot) }
 //!         }
 //!         pub unsafe fn x<E>(
 //!             self,
 //!             slot: *mut usize,
+//!             // Since `x` is not `#[pin]`, this is `Init`.
 //!             init: impl ::pinned_init::Init<usize, E>,
 //!         ) -> ::core::result::Result<(), E> {
 //!             unsafe { ::pinned_init::Init::__init(init, slot) }
 //!         }
 //!     }
 //!     // Implement the internal `HasPinData` trait that associates `Bar` with the pin-data struct
-//!     // that we constructed beforehand.
+//!     // that we constructed above.
 //!     unsafe impl<T> ::pinned_init::__internal::HasPinData for Bar<T> {
 //!         type PinData = __ThePinData<T>;
 //!         unsafe fn __pin_data() -> Self::PinData {
@@ -164,6 +167,8 @@
 //!     struct __Unpin<'__pin, T> {
 //!         __phantom_pin: ::core::marker::PhantomData<fn(&'__pin ()) -> &'__pin ()>,
 //!         __phantom: ::core::marker::PhantomData<fn(Bar<T>) -> Bar<T>>,
+//!         // Our only `#[pin]` field is `t`.
+//!         t: T,
 //!     }
 //!     #[doc(hidden)]
 //!     impl<'__pin, T>
@@ -220,7 +225,7 @@
 //!             // - we `use` the `HasPinData` trait in the block, it is only available in that
 //!             //   scope.
 //!             let data = unsafe {
-//!                 use pinned_init::__internal::HasPinData;
+//!                 use ::pinned_init::__internal::HasPinData;
 //!                 Self::__pin_data()
 //!             };
 //!             // Use `data` to help with type inference, the closure supplied will have the type
@@ -236,25 +241,31 @@
 //!                     // that will refer to this struct instead of the one defined above.
 //!                     struct __InitOk;
 //!                     // This is the expansion of `t,`, which is syntactic sugar for `t: t,`.
-//!                     unsafe { ::core::ptr::write(&raw mut (*slot).t, t) };
+//!                     unsafe { ::core::ptr::write(::core::addr_of_mut!((*slot).t), t) };
 //!                     // Since initialization could fail later (not in this case, since the error
-//!                     // type is `Infallible`) we will need to drop this field if it fails. This
-//!                     // `DropGuard` will drop the field when it gets dropped and has not yet
-//!                     // been forgotten. We make a reference to it, so users cannot `mem::forget`
-//!                     // it from the initializer, since the name is the same as the field.
+//!                     // type is `Infallible`) we will need to drop this field if there is an
+//!                     // error later. This `DropGuard` will drop the field when it gets dropped
+//!                     // and has not yet been forgotten. We make a reference to it, so users
+//!                     // cannot `mem::forget` it from the initializer, since the name is the same
+//!                     // as the field (including hygiene).
 //!                     let t = &unsafe {
-//!                         ::pinned_init::__internal::DropGuard::new(&raw mut (*slot).t)
+//!                         ::pinned_init::__internal::DropGuard::new(
+//!                             ::core::addr_of_mut!((*slot).t),
+//!                         )
 //!                     };
 //!                     // Expansion of `x: 0,`:
 //!                     // Since this can be an arbitrary expression we cannot place it inside of
 //!                     // the `unsafe` block, so we bind it here.
 //!                     let x = 0;
-//!                     unsafe { ::core::ptr::write(&raw mut (*slot).x, x) };
+//!                     unsafe { ::core::ptr::write(::core::addr_of_mut!((*slot).x), x) };
+//!                     // We again create a `DropGuard`.
 //!                     let x = &unsafe {
-//!                         ::pinned_init::__internal::DropGuard::new(&raw mut (*slot).x)
+//!                         ::pinned_init::__internal::DropGuard::new(
+//!                             ::core::addr_of_mut!((*slot).x),
+//!                         )
 //!                     };
 //!
-//!                     // Here we use the type checker to ensuer that every field has been
+//!                     // Here we use the type checker to ensure that every field has been
 //!                     // initialized exactly once, since this is `if false` it will never get
 //!                     // executed, but still type-checked.
 //!                     // Additionally we abuse `slot` to automatically infer the correct type for
@@ -276,7 +287,7 @@
 //!                         };
 //!                     }
 //!                     // Since initialization has successfully completed, we can now forget the
-//!                     // guards.
+//!                     // guards. This is not `mem::forget`, since we only have `&DropGuard`.
 //!                     unsafe { ::pinned_init::__internal::DropGuard::forget(t) };
 //!                     unsafe { ::pinned_init::__internal::DropGuard::forget(x) };
 //!                 }
@@ -284,7 +295,7 @@
 //!                 // `__InitOk` that we need to return.
 //!                 Ok(__InitOk)
 //!             });
-//!             // Change the return type of the closure.
+//!             // Change the return type from `__InitOk` to `()`.
 //!             let init = move |slot| -> ::core::result::Result<(), ::core::convert::Infallible> {
 //!                 init(slot).map(|__InitOk| ())
 //!             };
@@ -334,8 +345,6 @@
 //!         unsafe fn b<E>(
 //!             self,
 //!             slot: *mut Bar<u32>,
-//!             // Note that this is `PinInit` instead of `Init`, this is because `b` is
-//!             // structurally pinned, as marked by the `#[pin]` attribute.
 //!             init: impl ::pinned_init::PinInit<Bar<u32>, E>,
 //!         ) -> ::core::result::Result<(), E> {
 //!             unsafe { ::pinned_init::PinInit::__pinned_init(init, slot) }
@@ -363,14 +372,13 @@
 //!     struct __Unpin<'__pin> {
 //!         __phantom_pin: ::core::marker::PhantomData<fn(&'__pin ()) -> &'__pin ()>,
 //!         __phantom: ::core::marker::PhantomData<fn(Foo) -> Foo>,
-//!         // Since this field is `#[pin]`, it is listed here.
 //!         b: Bar<u32>,
 //!     }
 //!     #[doc(hidden)]
 //!     impl<'__pin> ::core::marker::Unpin for Foo where __Unpin<'__pin>: ::core::marker::Unpin {}
 //!     // Since we specified `PinnedDrop` as the argument to `#[pin_data]`, we expect `Foo` to
 //!     // implement `PinnedDrop`. Thus we do not need to prevent `Drop` implementations like
-//!     // before, instead we implement it here and delegate to `PinnedDrop`.
+//!     // before, instead we implement `Drop` here and delegate to `PinnedDrop`.
 //!     impl ::core::ops::Drop for Foo {
 //!         fn drop(&mut self) {
 //!             // Since we are getting dropped, no one else has a reference to `self` and thus we
@@ -414,8 +422,8 @@
 //!
 //! ## `pin_init!` on `Foo`
 //!
-//! Since we already took a look at `pin_init!` on `Bar`, this section will only explain the
-//! differences/new things in the expansion of `pin_init!` on `Foo`:
+//! Since we already took a look at `pin_init!` on `Bar`, this section will only show the expansion
+//! of `pin_init!` on `Foo`:
 //!
 //! ```rust,ignore
 //! let a = 42;
@@ -432,7 +440,7 @@
 //! let initializer = {
 //!     struct __InitOk;
 //!     let data = unsafe {
-//!         use pinned_init::__internal::HasPinData;
+//!         use ::pinned_init::__internal::HasPinData;
 //!         Foo::__pin_data()
 //!     };
 //!     let init = ::pinned_init::__internal::PinData::make_closure::<
@@ -442,13 +450,15 @@
 //!     >(data, move |slot| {
 //!         {
 //!             struct __InitOk;
-//!             unsafe { ::core::ptr::write(&raw mut (*slot).a, a) };
-//!             let a = &unsafe { ::pinned_init::__internal::DropGuard::new(&raw mut (*slot).a) };
+//!             unsafe { ::core::ptr::write(::core::addr_of_mut!((*slot).a), a) };
+//!             let a = &unsafe {
+//!                 ::pinned_init::__internal::DropGuard::new(::core::addr_of_mut!((*slot).a))
+//!             };
 //!             let b = Bar::new(36);
-//!             // Here we use `data` to access the correct field and require that `b` is of type
-//!             // `PinInit<Bar<u32>, Infallible>`.
-//!             unsafe { data.b(&raw mut (*slot).b, b)? };
-//!             let b = &unsafe { ::pinned_init::__internal::DropGuard::new(&raw mut (*slot).b) };
+//!             unsafe { data.b(::core::addr_of_mut!((*slot).b), b)? };
+//!             let b = &unsafe {
+//!                 ::pinned_init::__internal::DropGuard::new(::core::addr_of_mut!((*slot).b))
+//!             };
 //!
 //!             #[allow(unreachable_code, clippy::diverging_sub_expression)]
 //!             if false {


### PR DESCRIPTION
Introduce a helper trait in the macro to refer to the exact field types with `Self` correctly resolved.