### PR TITLE
UB fix: remove impl Zeroable for Infallible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1485,8 +1485,9 @@ impl_zeroable! {
     i8, i16, i32, i64, i128, isize,
     f32, f64,
 
-    // SAFETY: These are ZSTs, there is nothing to zero.
-    {<T: ?Sized>} PhantomData<T>, core::marker::PhantomPinned, Infallible, (),
+    // SAFETY: These are inhabited ZSTs, there is nothing to zero
+    // and a valid value exists.
+    {<T: ?Sized>} PhantomData<T>, core::marker::PhantomPinned, (),
 
     // SAFETY: Type is allowed to take any value, including all zeros.
     {<T>} MaybeUninit<T>,


### PR DESCRIPTION
It is not enough for a type to be a ZST to guarantee that zeroed memory is a valid value for it; it must also be inhabited.  Creating a value of an uninhabited type, ZST or no, is immediate UB.