### PR TITLE
Do not require nightly for no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,9 @@
 
 #![forbid(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(allocator_api)]
-#![cfg_attr(any(feature = "alloc"), feature(new_uninit))]
-#![cfg_attr(any(feature = "alloc"), feature(get_mut_unchecked))]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
+#![cfg_attr(feature = "alloc", feature(new_uninit))]
+#![cfg_attr(feature = "alloc", feature(get_mut_unchecked))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -249,7 +249,6 @@ use alloc::boxed::Box;
 use alloc::sync::Arc;
 
 use core::{
-    alloc::AllocError,
     cell::UnsafeCell,
     convert::Infallible,
     marker::PhantomData,
@@ -258,6 +257,9 @@ use core::{
     pin::Pin,
     ptr::{self, NonNull},
 };
+
+#[cfg(feature = "alloc")]
+use core::alloc::AllocError;
 
 #[doc(hidden)]
 pub mod __internal;
@@ -1092,6 +1094,7 @@ unsafe impl<T, E> PinInit<T, E> for T {
 }
 
 /// Smart pointer that can initialize memory in-place.
+#[cfg(feature = "alloc")]
 pub trait InPlaceInit<T>: Sized {
     /// Use the given pin-initializer to pin-initialize a `T` inside of a new smart pointer of this
     /// type.


### PR DESCRIPTION
This PR puts the `InPlaceInit` trait behind the a `#[cfg(feature = "alloc")]` flag, which - in turn - allows us to only require the unstable `core::alloc::AllocError` type when feature `alloc` (or `std`) is enabled.

Thus, the `no_std` portion of this crate compiles on stable Rust.
I need this because [`rs-matter`](https://github.com/project-chip/rs-matter/pull/198) - where we might start using `pinned-init` - requires Rust stable. Since `rs-matter` is `no_std` (and `no-alloc`) we don't really need that much if at all the smart-pointer in-place initialization logic of `InPlaceInit`. Not to mention that its `Arc`/`Rc`/`Box` implementations currently depend on other nightly features anyway so we can't use those.

The justification for putting the `InPlaceInit` trait behind the `alloc` feature is that I'm struggling a bit to find use cases for it when the `alloc` module is not enabled. While it is indeed generic and can be used for custom smart pointers, still:
* It is designed to decorate _existing_ smart pointers. Namely and (primarily?) the ones from the `alloc` crate
* If I have a custom smart-pointer, I would not decorate it with `InPlaceInit`, but would rather just implement the `init` method & friends directly on the custom smart pointer?

An alternative to the change here is to introduce another feature: `in-place-init` and then hide the `InPlaceInit` trait behind this feature, which would be enabled by default when `alloc` is enabled.

I'm fine with either of these approaches.
What would be your suggestion?
