### PR TITLE
Fix CI and sync with Linux 6.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ trybuild = { version = "1.0", features = ["diff"] }
 macrotest = "1.0"
 # needed for macrotest, have to enable verbatim feature to be able to format `&raw` expressions.
 prettyplease = { version = "0.2", features = ["verbatim"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(NO_UI_TESTS)', 'cfg(NO_ALLOC_FAIL_TESTS)'] }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ This library allows you to do in-place initialization safely.
 This library requires unstable features when the `alloc` or `std` features are enabled and thus
 can only be used with a nightly compiler. The internally used features are:
 - `allocator_api`
-- `new_uninit`
 - `get_mut_unchecked`
 
 When enabling the `alloc` or `std` feature, the user will be required to activate these features:

--- a/examples/big_struct_in_place.rs
+++ b/examples/big_struct_in_place.rs
@@ -1,5 +1,3 @@
-#![feature(allocator_api)]
-
 use pinned_init::*;
 
 // Struct with size over 1GiB

--- a/examples/big_struct_in_place.rs
+++ b/examples/big_struct_in_place.rs
@@ -1,7 +1,5 @@
 #![feature(allocator_api)]
 
-use std::convert::Infallible;
-
 use pinned_init::*;
 
 // Struct with size over 1GiB

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -1,6 +1,8 @@
-#![feature(allocator_api)]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
 
 use core::convert::Infallible;
+
+#[cfg(feature = "alloc")]
 use std::alloc::AllocError;
 
 #[derive(Debug)]
@@ -12,6 +14,7 @@ impl From<Infallible> for Error {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl From<AllocError> for Error {
     fn from(_: AllocError) -> Self {
         Self

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -7,8 +7,8 @@ use std::alloc::AllocError;
 pub struct Error;
 
 impl From<Infallible> for Error {
-    fn from(_: Infallible) -> Self {
-        Self
+    fn from(e: Infallible) -> Self {
+        match e {}
     }
 }
 

--- a/src/__internal.rs
+++ b/src/__internal.rs
@@ -261,3 +261,32 @@ impl OnlyCallFromDrop {
         Self(())
     }
 }
+
+/// Initializer that always fails.
+///
+/// Used by [`assert_pinned!`].
+///
+/// [`assert_pinned!`]: crate::assert_pinned
+pub struct AlwaysFail<T: ?Sized> {
+    _t: PhantomData<T>,
+}
+
+impl<T: ?Sized> AlwaysFail<T> {
+    /// Creates a new initializer that always fails.
+    pub fn new() -> Self {
+        Self { _t: PhantomData }
+    }
+}
+
+impl<T: ?Sized> Default for AlwaysFail<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// SAFETY: `__pinned_init` always fails, which is always okay.
+unsafe impl<T: ?Sized> PinInit<T, ()> for AlwaysFail<T> {
+    unsafe fn __pinned_init(self, _slot: *mut T) -> Result<(), ()> {
+        Err(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@
 //! This library requires unstable features when the `alloc` or `std` features are enabled and thus
 //! can only be used with a nightly compiler. The internally used features are:
 //! - `allocator_api`
-//! - `new_uninit`
 //! - `get_mut_unchecked`
 //!
 //! When enabling the `alloc` or `std` feature, the user will be required to activate these features:
@@ -237,7 +236,6 @@
 #![forbid(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(feature = "alloc", feature(new_uninit))]
 #![cfg_attr(feature = "alloc", feature(get_mut_unchecked))]
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,6 +745,75 @@ macro_rules! try_init {
     };
 }
 
+/// Asserts that a field on a struct using `#[pin_data]` is marked with `#[pin]` ie. that it is
+/// structurally pinned.
+///
+/// # Example
+///
+/// This will succeed:
+/// ```
+/// use pinned_init::*;
+/// #[pin_data]
+/// struct MyStruct {
+///     #[pin]
+///     some_field: u64,
+/// }
+///
+/// assert_pinned!(MyStruct, some_field, u64);
+/// ```
+///
+/// This will fail:
+// TODO: replace with `compile_fail` when supported.
+/// ```ignore
+/// # use pinned_init::*;
+/// #[pin_data]
+/// struct MyStruct {
+///     some_field: u64,
+/// }
+///
+/// assert_pinned!(MyStruct, some_field, u64);
+/// ```
+///
+/// Some uses of the macro may trigger the `can't use generic parameters from outer item` error. To
+/// work around this, you may pass the `inline` parameter to the macro. The `inline` parameter can
+/// only be used when the macro is invoked from a function body.
+/// ```
+/// # use pinned_init::*;
+/// # use core::pin::Pin;
+/// #[pin_data]
+/// struct Foo<T> {
+///     #[pin]
+///     elem: T,
+/// }
+///
+/// impl<T> Foo<T> {
+///     fn project(self: Pin<&mut Self>) -> Pin<&mut T> {
+///         assert_pinned!(Foo<T>, elem, T, inline);
+///
+///         // SAFETY: The field is structurally pinned.
+///         unsafe { self.map_unchecked_mut(|me| &mut me.elem) }
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! assert_pinned {
+    ($ty:ty, $field:ident, $field_ty:ty, inline) => {
+        let _ = move |ptr: *mut $field_ty| {
+            // SAFETY: This code is unreachable.
+            let data = unsafe { <$ty as $crate::__internal::HasPinData>::__pin_data() };
+            let init = $crate::__internal::AlwaysFail::<$field_ty>::new();
+            // SAFETY: This code is unreachable.
+            unsafe { data.$field(ptr, init) }.ok();
+        };
+    };
+
+    ($ty:ty, $field:ident, $field_ty:ty) => {
+        const _: () = {
+            $crate::assert_pinned!($ty, $field, $field_ty, inline);
+        };
+    };
+}
+
 /// A pin-initializer for the type `T`.
 ///
 /// To use this initializer, you will need a suitable memory location that can hold a `T`. This can

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,11 +824,8 @@ where
         let val = unsafe { &mut *slot };
         // SAFETY: `slot` is considered pinned.
         let val = unsafe { Pin::new_unchecked(val) };
-        (self.1)(val).map_err(|e| {
-            // SAFETY: `slot` was initialized above.
-            unsafe { core::ptr::drop_in_place(slot) };
-            e
-        })
+        // SAFETY: `slot` was initialized above.
+        (self.1)(val).inspect_err(|_| unsafe { core::ptr::drop_in_place(slot) })
     }
 }
 
@@ -922,11 +919,9 @@ where
         // SAFETY: All requirements fulfilled since this function is `__init`.
         unsafe { self.0.__pinned_init(slot)? };
         // SAFETY: The above call initialized `slot` and we still have unique access.
-        (self.1)(unsafe { &mut *slot }).map_err(|e| {
+        (self.1)(unsafe { &mut *slot }).inspect_err(|_|
             // SAFETY: `slot` was initialized above.
-            unsafe { core::ptr::drop_in_place(slot) };
-            e
-        })
+            unsafe { core::ptr::drop_in_place(slot) })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1137,13 +1137,7 @@ impl<T> InPlaceInit<T> for Box<T> {
     where
         E: From<AllocError>,
     {
-        let mut this = Box::try_new_uninit()?;
-        let slot = this.as_mut_ptr();
-        // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
-        // slot is valid and will not be moved, because we pin it later.
-        unsafe { init.__pinned_init(slot)? };
-        // SAFETY: All fields have been initialized.
-        Ok(unsafe { this.assume_init() }.into())
+        Box::try_new_uninit()?.write_pin_init(init)
     }
 
     #[inline]
@@ -1151,13 +1145,7 @@ impl<T> InPlaceInit<T> for Box<T> {
     where
         E: From<AllocError>,
     {
-        let mut this = Box::try_new_uninit()?;
-        let slot = this.as_mut_ptr();
-        // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
-        // slot is valid.
-        unsafe { init.__init(slot)? };
-        // SAFETY: All fields have been initialized.
-        Ok(unsafe { this.assume_init() })
+        Box::try_new_uninit()?.write_init(init)
     }
 }
 
@@ -1168,14 +1156,7 @@ impl<T> InPlaceInit<T> for Arc<T> {
     where
         E: From<AllocError>,
     {
-        let mut this = Arc::try_new_uninit()?;
-        let slot = unsafe { Arc::get_mut_unchecked(&mut this) };
-        let slot = slot.as_mut_ptr();
-        // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
-        // slot is valid and will not be moved, because we pin it later.
-        unsafe { init.__pinned_init(slot)? };
-        // SAFETY: All fields have been initialized and this is the only `Arc` to that data.
-        Ok(unsafe { Pin::new_unchecked(this.assume_init()) })
+        Arc::try_new_uninit()?.write_pin_init(init)
     }
 
     #[inline]
@@ -1183,14 +1164,71 @@ impl<T> InPlaceInit<T> for Arc<T> {
     where
         E: From<AllocError>,
     {
-        let mut this = Arc::try_new_uninit()?;
-        let slot = unsafe { Arc::get_mut_unchecked(&mut this) };
+        Arc::try_new_uninit()?.write_init(init)
+    }
+}
+
+/// Smart pointer containing uninitialized memory and that can write a value.
+pub trait InPlaceWrite<T> {
+    /// The type `Self` turns into when the contents are initialized.
+    type Initialized;
+
+    /// Use the given initializer to write a value into `self`.
+    ///
+    /// Does not drop the current value and considers it as uninitialized memory.
+    fn write_init<E>(self, init: impl Init<T, E>) -> Result<Self::Initialized, E>;
+
+    /// Use the given pin-initializer to write a value into `self`.
+    ///
+    /// Does not drop the current value and considers it as uninitialized memory.
+    fn write_pin_init<E>(self, init: impl PinInit<T, E>) -> Result<Pin<Self::Initialized>, E>;
+}
+
+#[cfg(feature = "alloc")]
+impl<T> InPlaceWrite<T> for Box<MaybeUninit<T>> {
+    type Initialized = Box<T>;
+
+    fn write_init<E>(mut self, init: impl Init<T, E>) -> Result<Self::Initialized, E> {
+        let slot = self.as_mut_ptr();
+        // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid.
+        unsafe { init.__init(slot)? };
+        // SAFETY: All fields have been initialized.
+        Ok(unsafe { self.assume_init() })
+    }
+
+    fn write_pin_init<E>(mut self, init: impl PinInit<T, E>) -> Result<Pin<Self::Initialized>, E> {
+        let slot = self.as_mut_ptr();
+        // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid and will not be moved, because we pin it later.
+        unsafe { init.__pinned_init(slot)? };
+        // SAFETY: All fields have been initialized.
+        Ok(unsafe { self.assume_init() }.into())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T> InPlaceWrite<T> for Arc<MaybeUninit<T>> {
+    type Initialized = Arc<T>;
+
+    fn write_init<E>(mut self, init: impl Init<T, E>) -> Result<Self::Initialized, E> {
+        let slot = unsafe { Arc::get_mut_unchecked(&mut self) };
         let slot = slot.as_mut_ptr();
         // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
         // slot is valid.
         unsafe { init.__init(slot)? };
         // SAFETY: All fields have been initialized.
-        Ok(unsafe { this.assume_init() })
+        Ok(unsafe { self.assume_init() })
+    }
+
+    fn write_pin_init<E>(mut self, init: impl PinInit<T, E>) -> Result<Pin<Self::Initialized>, E> {
+        let slot = unsafe { Arc::get_mut_unchecked(&mut self) };
+        let slot = slot.as_mut_ptr();
+        // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
+        // slot is valid and will not be moved, because we pin it later.
+        unsafe { init.__pinned_init(slot)? };
+        // SAFETY: All fields have been initialized and this is the only `Arc` to that data.
+        Ok(unsafe { Pin::new_unchecked(self.assume_init()) })
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -145,7 +145,7 @@
 //!         }
 //!     }
 //!     // Implement the internal `PinData` trait that marks the pin-data struct as a pin-data
-//!     // struct. This is important to ensure that no user can implement a rouge `__pin_data`
+//!     // struct. This is important to ensure that no user can implement a rogue `__pin_data`
 //!     // function without using `unsafe`.
 //!     unsafe impl<T> ::pinned_init::__internal::PinData for __ThePinData<T> {
 //!         type Datee = Bar<T>;
@@ -156,7 +156,7 @@
 //!     // case no such fields exist, hence this is almost empty. The two phantomdata fields exist
 //!     // for two reasons:
 //!     // - `__phantom`: every generic must be used, since we cannot really know which generics
-//!     //   are used, we declere all and then use everything here once.
+//!     //   are used, we declare all and then use everything here once.
 //!     // - `__phantom_pin`: uses the `'__pin` lifetime and ensures that this struct is invariant
 //!     //   over it. The lifetime is needed to work around the limitation that trait bounds must
 //!     //   not be trivial, e.g. the user has a `#[pin] PhantomPinned` field -- this is

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -250,7 +250,7 @@
 //!                     // error type is `Infallible`) we will need to drop this field if there
 //!                     // is an error later. This `DropGuard` will drop the field when it gets
 //!                     // dropped and has not yet been forgotten.
-//!                     let t = unsafe {
+//!                     let __t_guard = unsafe {
 //!                         ::pinned_init::__internal::DropGuard::new(::core::addr_of_mut!((*slot).t))
 //!                     };
 //!                     // Expansion of `x: 0,`:
@@ -261,14 +261,14 @@
 //!                         unsafe { ::core::ptr::write(::core::addr_of_mut!((*slot).x), x) };
 //!                     }
 //!                     // We again create a `DropGuard`.
-//!                     let x = unsafe {
+//!                     let __x_guard = unsafe {
 //!                         ::pinned_init::__internal::DropGuard::new(::core::addr_of_mut!((*slot).x))
 //!                     };
 //!                     // Since initialization has successfully completed, we can now forget
 //!                     // the guards. This is not `mem::forget`, since we only have
 //!                     // `&DropGuard`.
-//!                     ::core::mem::forget(x);
-//!                     ::core::mem::forget(t);
+//!                     ::core::mem::forget(__x_guard);
+//!                     ::core::mem::forget(__t_guard);
 //!                     // Here we use the type checker to ensure that every field has been
 //!                     // initialized exactly once, since this is `if false` it will never get
 //!                     // executed, but still type-checked.
@@ -461,16 +461,16 @@
 //!             {
 //!                 unsafe { ::core::ptr::write(::core::addr_of_mut!((*slot).a), a) };
 //!             }
-//!             let a = unsafe {
+//!             let __a_guard = unsafe {
 //!                 ::pinned_init::__internal::DropGuard::new(::core::addr_of_mut!((*slot).a))
 //!             };
 //!             let init = Bar::new(36);
 //!             unsafe { data.b(::core::addr_of_mut!((*slot).b), b)? };
-//!             let b = unsafe {
+//!             let __b_guard = unsafe {
 //!                 ::pinned_init::__internal::DropGuard::new(::core::addr_of_mut!((*slot).b))
 //!             };
-//!             ::core::mem::forget(b);
-//!             ::core::mem::forget(a);
+//!             ::core::mem::forget(__b_guard);
+//!             ::core::mem::forget(__a_guard);
 //!             #[allow(unreachable_code, clippy::diverging_sub_expression)]
 //!             let _ = || {
 //!                 unsafe {
@@ -1209,14 +1209,14 @@ macro_rules! __init_internal {
         // We use `paste!` to create new hygiene for `$field`.
         $crate::macros::paste! {
             // SAFETY: We forget the guard later when initialization has succeeded.
-            let [<$field>] = unsafe {
+            let [< __ $field _guard >] = unsafe {
                 $crate::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
             };
 
             $crate::__init_internal!(init_slot($use_data):
                 @data($data),
                 @slot($slot),
-                @guards([<$field>], $($guards,)*),
+                @guards([< __ $field _guard >], $($guards,)*),
                 @munch_fields($($rest)*),
             );
         }
@@ -1240,14 +1240,14 @@ macro_rules! __init_internal {
         // We use `paste!` to create new hygiene for `$field`.
         $crate::macros::paste! {
             // SAFETY: We forget the guard later when initialization has succeeded.
-            let [<$field>] = unsafe {
+            let [< __ $field _guard >] = unsafe {
                 $crate::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
             };
 
             $crate::__init_internal!(init_slot():
                 @data($data),
                 @slot($slot),
-                @guards([<$field>], $($guards,)*),
+                @guards([< __ $field _guard >], $($guards,)*),
                 @munch_fields($($rest)*),
             );
         }
@@ -1272,14 +1272,14 @@ macro_rules! __init_internal {
         // We use `paste!` to create new hygiene for `$field`.
         $crate::macros::paste! {
             // SAFETY: We forget the guard later when initialization has succeeded.
-            let [<$field>] = unsafe {
+            let [< __ $field _guard >] = unsafe {
                 $crate::__internal::DropGuard::new(::core::ptr::addr_of_mut!((*$slot).$field))
             };
 
             $crate::__init_internal!(init_slot($($use_data)?):
                 @data($data),
                 @slot($slot),
-                @guards([<$field>], $($guards,)*),
+                @guards([< __ $field _guard >], $($guards,)*),
                 @munch_fields($($rest)*),
             );
         }

--- a/tests/const-generic-default.rs
+++ b/tests/const-generic-default.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use pinned_init::*;
 
 #[pin_data]

--- a/tests/ui/compile-fail/init/missing_comma.stderr
+++ b/tests/ui/compile-fail/init/missing_comma.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `c`
+error: no rules expected `c`
   --> tests/ui/compile-fail/init/missing_comma.rs:16:9
    |
 16 |         c: Bar,
@@ -10,7 +10,7 @@ note: while trying to match `,`
    |         @munch_fields($field:ident $(: $val:expr)?, $($rest:tt)*),
    |                                                   ^
 
-error: no rules expected the token `c`
+error: no rules expected `c`
   --> tests/ui/compile-fail/init/missing_comma.rs:16:9
    |
 16 |         c: Bar,

--- a/tests/ui/compile-fail/init/missing_comma_with_zeroable.stderr
+++ b/tests/ui/compile-fail/init/missing_comma_with_zeroable.stderr
@@ -1,19 +1,13 @@
-error[E0782]: trait objects must include the `dyn` keyword
+error[E0782]: expected a type, found a trait
   --> tests/ui/compile-fail/init/missing_comma_with_zeroable.rs:12:15
    |
 12 |         a: 0..Zeroable::zeroed()
    |               ^^^^^^^^
    |
-help: add `dyn` keyword before this trait
+help: you can add the `dyn` keyword if you want a trait object
    |
 12 |         a: 0..<dyn Zeroable>::zeroed()
    |               ++++         +
-
-error[E0599]: no function or associated item named `zeroed` found for trait `pinned_init::Zeroable`
-  --> tests/ui/compile-fail/init/missing_comma_with_zeroable.rs:12:25
-   |
-12 |         a: 0..Zeroable::zeroed()
-   |                         ^^^^^^ function or associated item not found in `Zeroable`
 
 error[E0308]: mismatched types
   --> tests/ui/compile-fail/init/missing_comma_with_zeroable.rs:11:13

--- a/tests/ui/compile-fail/init/no_error_coercion.stderr
+++ b/tests/ui/compile-fail/init/no_error_coercion.stderr
@@ -5,7 +5,7 @@ error[E0277]: `?` couldn't convert the error to `std::alloc::AllocError`
 17 | |             a: Box::new(42),
 18 | |             bar <- init!(Bar { b: 42 }),
 19 | |         }? AllocError)
-   | |______________________^ the trait `From<Infallible>` is not implemented for `std::alloc::AllocError`, which is required by `Result<Foo::new::__InitOk, std::alloc::AllocError>: FromResidual<Result<Infallible, Infallible>>`
+   | |______________________^ the trait `From<Infallible>` is not implemented for `std::alloc::AllocError`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the trait `FromResidual<Result<Infallible, E>>` is implemented for `Result<T, F>`

--- a/tests/ui/compile-fail/init/wrong_generics.stderr
+++ b/tests/ui/compile-fail/init/wrong_generics.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `<`
+error: no rules expected `<`
  --> tests/ui/compile-fail/init/wrong_generics.rs:7:22
   |
 7 |     let _ = init!(Foo<()> {

--- a/tests/ui/compile-fail/pin_data/missing_pin.stderr
+++ b/tests/ui/compile-fail/pin_data/missing_pin.stderr
@@ -7,7 +7,8 @@ error[E0277]: the trait bound `impl PinInit<usize>: Init<usize, _>` is not satis
 13 | |         })
    | |__________^ the trait `Init<usize, _>` is not implemented for `impl PinInit<usize>`
    |
-   = help: the trait `Init<impl PinInit<usize>, _>` is implemented for `impl PinInit<usize>`
+   = help: the trait `Init<usize, _>` is not implemented for `impl PinInit<usize>`
+           but trait `Init<impl PinInit<usize>, _>` is implemented for it
    = help: for that trait implementation, expected `impl PinInit<usize>`, found `usize`
 note: required by a bound in `__ThePinData::a`
   --> tests/ui/compile-fail/pin_data/missing_pin.rs:4:1

--- a/tests/ui/compile-fail/pin_data/unexpected_item.stderr
+++ b/tests/ui/compile-fail/pin_data/unexpected_item.stderr
@@ -1,10 +1,10 @@
-error: no rules expected the token `fn`
+error: no rules expected keyword `fn`
  --> tests/ui/compile-fail/pin_data/unexpected_item.rs:4:1
   |
 4 | fn foo() {}
   | ^^ no rules expected this token in macro call
   |
-note: while trying to match `struct`
+note: while trying to match keyword `struct`
  --> src/macros.rs
   |
   |             $vis:vis struct $name:ident

--- a/tests/ui/compile-fail/pinned_drop/no_fn.stderr
+++ b/tests/ui/compile-fail/pinned_drop/no_fn.stderr
@@ -1,10 +1,10 @@
-error: no rules expected the token `)`
+error: no rules expected `)`
  --> tests/ui/compile-fail/pinned_drop/no_fn.rs:6:1
   |
 6 | #[pinned_drop]
   | ^^^^^^^^^^^^^^ no rules expected this token in macro call
   |
-note: while trying to match `fn`
+note: while trying to match keyword `fn`
  --> src/macros.rs
   |
   |             fn drop($($sig:tt)*) {

--- a/tests/ui/compile-fail/pinned_drop/unexpected_additional_item.stderr
+++ b/tests/ui/compile-fail/pinned_drop/unexpected_additional_item.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `const`
+error: no rules expected keyword `const`
   --> tests/ui/compile-fail/pinned_drop/unexpected_additional_item.rs:10:5
    |
 10 |     const BAZ: usize = 0;

--- a/tests/ui/compile-fail/pinned_drop/unexpected_item.stderr
+++ b/tests/ui/compile-fail/pinned_drop/unexpected_item.stderr
@@ -1,10 +1,10 @@
-error: no rules expected the token `const`
+error: no rules expected keyword `const`
  --> tests/ui/compile-fail/pinned_drop/unexpected_item.rs:8:5
   |
 8 |     const BAZ: usize = 0;
   |     ^^^^^ no rules expected this token in macro call
   |
-note: while trying to match `fn`
+note: while trying to match keyword `fn`
  --> src/macros.rs
   |
   |             fn drop($($sig:tt)*) {

--- a/tests/ui/compile-fail/zeroable/with_comma.stderr
+++ b/tests/ui/compile-fail/zeroable/with_comma.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `,`
+error: no rules expected `,`
   --> tests/ui/compile-fail/zeroable/with_comma.rs:11:13
    |
 11 |       let _ = init!(Foo {
@@ -15,7 +15,7 @@ note: while trying to match `)`
    |                                                     ^
    = note: this error originates in the macro `$crate::__init_internal` which comes from the expansion of the macro `init` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `,`
+error: no rules expected `,`
   --> tests/ui/compile-fail/zeroable/with_comma.rs:11:13
    |
 11 |       let _ = init!(Foo {


### PR DESCRIPTION
I've decided to retarget this PR to just syncing with Linux 6.12 before making further changes. In particular this brings in the `InPlaceWrite` trait.

# Old text

~~It is actually not that hard to make `pinned_init` usable with stable Rust. In particular:~~

* ~~`new_uninit` has been stabilized (and anyway in the end it was just a glorified `Box::<MaybeUninit<T>>::new()`)~~
* ~~`allocator_api` is needed to have fallible allocation, but not if you just replace `core::alloc::AllocError` with `core::convert::Infallible`~~
* ~~`get_mut_unchecked` is needed if you need `Arc`, but otherwise is not necessary.~~

~~This pull request fixes CI and isolates a little bit more the pieces of code that refer to `Arc` or `feature(allocator_api)`. The idea is that these are mostly uncontroversial changes that should not hamper readability and maintainability, and therefore can be committed separately.~~

~~Please let me know if I should submit separately the small changes to `src/lib.rs`, for example via the rust-for-linux mailing list.~~