### PR TITLE
Make pinned-init usable with 1.82.0+

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,22 +84,23 @@ jobs:
         run: cargo install cargo-rdme
       - name: cargo rdme --check
         run: cargo rdme --check
-# disable msrv, since we are nightly only
-# msrv:
-#   runs-on: ubuntu-latest
-#   # we use a matrix here just because env can't be used in job names
-#   # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-#   strategy:
-#     matrix:
-#       msrv: [1.61.0] # `impl Trait` requires this
-#   name: ubuntu / ${{ matrix.msrv }}
-#   steps:
-#     - uses: actions/checkout@v4
-#       with:
-#         submodules: true
-#     - name: Install ${{ matrix.msrv }}
-#       uses: dtolnay/rust-toolchain@master
-#       with:
-#         toolchain: ${{ matrix.msrv }}
-#     - name: cargo +${{ matrix.msrv }} check
-#       run: cargo check
+  msrv:
+    runs-on: ubuntu-latest
+    # we use a matrix here just because env can't be used in job names
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
+    strategy:
+      matrix:
+        msrv: [1.82.0] # new_uninit requires this
+    name: ubuntu / ${{ matrix.msrv }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install ${{ matrix.msrv }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.msrv }}
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - name: cargo hack
+        run: cargo +${{ matrix.msrv }} hack --feature-powerset --exclude-features alloc,default check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ paste = "1.0"
 pinned-init-macro = { path = "./pinned-init-macro", version = "=0.0.5" }
 
 [features]
-default = ["std"]
-std = ["alloc"]
+default = ["std", "alloc"]
+std = []
 alloc = []
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -26,13 +26,17 @@ it into it's final memory location.
 
 This library allows you to do in-place initialization safely.
 
-### Nightly Needed for `alloc` and `std` features
+### Nightly Needed for `alloc` feature
 
-This library requires the `allocator_api` unstable feature when the `alloc` or `std` features
-are enabled and thus can only be used with a nightly compiler.
+This library requires the `allocator_api` unstable feature when the `alloc` feature
+is enabled and thus this feature can only be used with a nightly compiler.
+When enabling the `alloc` feature, the user will be required to activate
+`allocator_api` as well.
 
-When enabling the `alloc` or `std` feature, the user will be required to activate `allocator_api`
-as well.
+The feature is enabled by default, thus by default `pinned-init` will require a
+nightly compiler. However, using the crate on stable compilers is possible by
+disabling `alloc`. In practice this will require the `std` feature, because
+stable compilers have neither `Box` nor `Arc` in no-std mode.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,11 @@ This library allows you to do in-place initialization safely.
 
 ### Nightly Needed for `alloc` and `std` features
 
-This library requires unstable features when the `alloc` or `std` features are enabled and thus
-can only be used with a nightly compiler. The internally used features are:
-- `allocator_api`
-- `get_mut_unchecked`
+This library requires the `allocator_api` unstable feature when the `alloc` or `std` features
+are enabled and thus can only be used with a nightly compiler.
 
-When enabling the `alloc` or `std` feature, the user will be required to activate these features:
-- `allocator_api`
+When enabling the `alloc` or `std` feature, the user will be required to activate `allocator_api`
+as well.
 
 ## Overview
 

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -1,4 +1,5 @@
-#![feature(allocator_api)]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
+
 use core::{
     cell::Cell,
     convert::Infallible,

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -1,4 +1,5 @@
-#![feature(allocator_api)]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
+
 use core::{
     cell::{Cell, UnsafeCell},
     marker::PhantomPinned,
@@ -161,8 +162,12 @@ impl WaitEntry {
     }
 }
 
+#[cfg(not(feature = "alloc"))]
+fn main() {}
+
 #[allow(dead_code)]
 #[cfg_attr(test, test)]
+#[cfg(feature = "alloc")]
 fn main() {
     let mtx: Pin<Arc<CMutex<usize>>> = Arc::pin_init(CMutex::new(0)).unwrap();
     let mut handles = vec![];

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -162,12 +162,12 @@ impl WaitEntry {
     }
 }
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(not(any(feature = "std", feature = "alloc")))]
 fn main() {}
 
 #[allow(dead_code)]
 #[cfg_attr(test, test)]
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 fn main() {
     let mtx: Pin<Arc<CMutex<usize>>> = Arc::pin_init(CMutex::new(0)).unwrap();
     let mut handles = vec![];

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -1,9 +1,10 @@
 // inspired by https://github.com/nbdd0121/pin-init/blob/trunk/examples/pthread_mutex.rs
-#![feature(allocator_api)]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
 #[cfg(not(windows))]
 mod pthread_mtx {
+    #[cfg(feature = "alloc")]
+    use core::alloc::AllocError;
     use core::{
-        alloc::AllocError,
         cell::UnsafeCell,
         marker::PhantomPinned,
         mem::MaybeUninit,
@@ -45,6 +46,8 @@ mod pthread_mtx {
             match e {}
         }
     }
+
+    #[cfg(feature = "alloc")]
     impl From<AllocError> for Error {
         fn from(_: AllocError) -> Self {
             Self::Alloc
@@ -129,7 +132,7 @@ mod pthread_mtx {
 
 #[cfg_attr(test, test)]
 fn main() {
-    #[cfg(not(windows))]
+    #[cfg(all(feature = "alloc", not(windows)))]
     {
         use core::pin::Pin;
         use pinned_init::*;

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -132,7 +132,7 @@ mod pthread_mtx {
 
 #[cfg_attr(test, test)]
 fn main() {
-    #[cfg(all(feature = "alloc", not(windows)))]
+    #[cfg(all(any(feature = "std", feature = "alloc"), not(windows)))]
     {
         use core::pin::Pin;
         use pinned_init::*;

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -77,10 +77,10 @@ unsafe impl PinInit<CMutex<usize>> for CountInit {
 
 pub static COUNT: StaticInit<CMutex<usize>, CountInit> = StaticInit::new(CountInit);
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(not(any(feature = "std", feature = "alloc")))]
 fn main() {}
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 fn main() {
     let mtx: Pin<Arc<CMutex<usize>>> = Arc::pin_init(CMutex::new(0)).unwrap();
     let mut handles = vec![];

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -1,4 +1,4 @@
-#![feature(allocator_api)]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
 
 use core::{
     cell::{Cell, UnsafeCell},
@@ -77,6 +77,10 @@ unsafe impl PinInit<CMutex<usize>> for CountInit {
 
 pub static COUNT: StaticInit<CMutex<usize>, CountInit> = StaticInit::new(CountInit);
 
+#[cfg(not(feature = "alloc"))]
+fn main() {}
+
+#[cfg(feature = "alloc")]
 fn main() {
     let mtx: Pin<Arc<CMutex<usize>>> = Arc::pin_init(CMutex::new(0)).unwrap();
     let mut handles = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,11 @@ use core::{
 #[cfg(feature = "alloc")]
 use core::alloc::AllocError;
 
+// Allocations are infallible without the allocator API.  In that case, just
+// require From<Infallible> for the trait that is passed to the try_* macros,
+#[cfg(not(feature = "alloc"))]
+type AllocError = Infallible;
+
 #[doc(hidden)]
 pub mod __internal;
 #[doc(hidden)]
@@ -1153,7 +1158,6 @@ unsafe impl<T, E> PinInit<T, E> for T {
 }
 
 /// Smart pointer that can initialize memory in-place.
-#[cfg(feature = "alloc")]
 pub trait InPlaceInit<T>: Sized {
     /// Use the given pin-initializer to pin-initialize a `T` inside of a new smart pointer of this
     /// type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,11 @@
 //!
 //! ## Nightly Needed for `alloc` and `std` features
 //!
-//! This library requires unstable features when the `alloc` or `std` features are enabled and thus
-//! can only be used with a nightly compiler. The internally used features are:
-//! - `allocator_api`
-//! - `get_mut_unchecked`
+//! This library requires the `allocator_api` unstable feature when the `alloc` or `std` features
+//! are enabled and thus can only be used with a nightly compiler.
 //!
-//! When enabling the `alloc` or `std` feature, the user will be required to activate these features:
-//! - `allocator_api`
+//! When enabling the `alloc` or `std` feature, the user will be required to activate `allocator_api`
+//! as well.
 //!
 //! # Overview
 //!
@@ -236,7 +234,6 @@
 #![forbid(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(feature = "alloc", feature(get_mut_unchecked))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -1226,7 +1223,10 @@ impl<T> InPlaceInit<T> for Arc<T> {
         E: From<AllocError>,
     {
         let mut this = Arc::try_new_uninit()?;
-        let slot = unsafe { Arc::get_mut_unchecked(&mut this) };
+        let Some(slot) = Arc::get_mut(&mut this) else {
+            // SAFETY: the Arc has just been created and has no external referecnes
+            unsafe { core::hint::unreachable_unchecked() }
+        };
         let slot = slot.as_mut_ptr();
         // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
         // slot is valid and will not be moved, because we pin it later.
@@ -1241,7 +1241,10 @@ impl<T> InPlaceInit<T> for Arc<T> {
         E: From<AllocError>,
     {
         let mut this = Arc::try_new_uninit()?;
-        let slot = unsafe { Arc::get_mut_unchecked(&mut this) };
+        let Some(slot) = Arc::get_mut(&mut this) else {
+            // SAFETY: the Arc has just been created and has no external referecnes
+            unsafe { core::hint::unreachable_unchecked() }
+        };
         let slot = slot.as_mut_ptr();
         // SAFETY: When init errors/panics, slot will get deallocated but not dropped,
         // slot is valid.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1274,7 +1274,7 @@ pub trait InPlaceWrite<T> {
     fn write_pin_init<E>(self, init: impl PinInit<T, E>) -> Result<Pin<Self::Initialized>, E>;
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 impl<T> InPlaceWrite<T> for Box<MaybeUninit<T>> {
     type Initialized = Box<T>;
 
@@ -1405,7 +1405,7 @@ impl_zeroable! {
     //
     // In this case we are allowed to use `T: ?Sized`, since all zeros is the `None` variant.
     {<T: ?Sized>} Option<NonNull<T>>,
-    #[cfg(feature = "alloc")]
+    #[cfg(any(feature = "std", feature = "alloc"))]
     {<T: ?Sized>} Option<Box<T>>,
 
     // SAFETY: `null` pointer is valid.

--- a/tests/alloc_fail.rs
+++ b/tests/alloc_fail.rs
@@ -1,6 +1,9 @@
-#![feature(allocator_api)]
+#![cfg_attr(feature = "alloc", feature(allocator_api))]
 
-use core::{alloc::AllocError, convert::Infallible};
+#[cfg(feature = "alloc")]
+use core::alloc::AllocError;
+
+use core::convert::Infallible;
 use pinned_init::*;
 use std::sync::Arc;
 
@@ -8,7 +11,12 @@ use std::sync::Arc;
 mod ring_buf;
 use ring_buf::*;
 
-#[cfg(all(not(miri), not(NO_ALLOC_FAIL_TESTS), not(target_os = "macos")))]
+#[cfg(all(
+    feature = "alloc",
+    not(miri),
+    not(NO_ALLOC_FAIL_TESTS),
+    not(target_os = "macos")
+))]
 #[test]
 fn too_big_pinned() {
     // should be too big with current hardware.
@@ -23,7 +31,12 @@ fn too_big_pinned() {
     ));
 }
 
-#[cfg(all(not(miri), not(NO_ALLOC_FAIL_TESTS), not(target_os = "macos")))]
+#[cfg(all(
+    feature = "alloc",
+    not(miri),
+    not(NO_ALLOC_FAIL_TESTS),
+    not(target_os = "macos")
+))]
 #[test]
 fn too_big_in_place() {
     // should be too big with current hardware.

--- a/tests/ring_buf.rs
+++ b/tests/ring_buf.rs
@@ -192,7 +192,7 @@ fn even_stack() {
     assert_eq!(val, Err(()));
 }
 
-#[cfg(feature = "alloc")]
+#[cfg(any(feature = "std", feature = "alloc"))]
 #[test]
 fn even_failing() {
     assert!(matches!(Box::try_pin_init(EvenU64::new2(3)), Err(Error)));
@@ -243,7 +243,7 @@ struct BigStruct {
     oth: MaybeUninit<u8>,
 }
 
-#[cfg(all(feature = "alloc", not(miri)))]
+#[cfg(all(any(feature = "std", feature = "alloc"), not(miri)))]
 #[test]
 fn big_struct() {
     let x = Arc::init(init!(BigStruct {
@@ -258,7 +258,7 @@ fn big_struct() {
     println!("{x:?}");
 }
 
-#[cfg(all(feature = "alloc", not(miri)))]
+#[cfg(all(any(feature = "std", feature = "alloc"), not(miri)))]
 #[test]
 fn with_big_struct() {
     let buf = Arc::pin_init(CMutex::new(RingBuffer::<BigStruct, 64>::new())).unwrap();

--- a/tests/ring_buf.rs
+++ b/tests/ring_buf.rs
@@ -192,9 +192,11 @@ fn even_stack() {
     assert_eq!(val, Err(()));
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn even_failing() {
     assert!(matches!(Box::try_pin_init(EvenU64::new2(3)), Err(Error)));
+    assert!(matches!(Box::try_init(EvenU64::new2(3)), Err(Error)));
     assert!(matches!(Arc::try_pin_init(EvenU64::new2(5)), Err(Error)));
     assert!(matches!(Box::try_init(EvenU64::new2(3)), Err(Error)));
     assert!(matches!(Arc::try_init(EvenU64::new2(5)), Err(Error)));
@@ -241,7 +243,7 @@ struct BigStruct {
     oth: MaybeUninit<u8>,
 }
 
-#[cfg(not(miri))]
+#[cfg(all(feature = "alloc", not(miri)))]
 #[test]
 fn big_struct() {
     let x = Arc::init(init!(BigStruct {
@@ -256,7 +258,7 @@ fn big_struct() {
     println!("{x:?}");
 }
 
-#[cfg(not(miri))]
+#[cfg(all(feature = "alloc", not(miri)))]
 #[test]
 fn with_big_struct() {
     let buf = Arc::pin_init(CMutex::new(RingBuffer::<BigStruct, 64>::new())).unwrap();


### PR DESCRIPTION
This pull request, on top of #23, makes it possible to use `pinned_init` with stable Rust. In particular:

* `new_uninit` has been stabilized (and anyway in the end it was just a glorified Box::<MaybeUninit<T>>::new())
* `allocator_api` is needed to have fallible allocation, but not if you just replace `core::alloc::AllocError` with `core::convert::Infallible`
* `get_mut_unchecked` is not needed, because after the introduction of `InPlaceWrite` you actually need to check that you're not writing to a shared `Arc`&mdash;thus `Arc::get_mut` is the right associated function to use.

The main work is to  isolate a little bit more the pieces of code that refer to `feature(allocator_api)`.

Successful CI run at bonzini/pinned-init#2.

Diff on top of #23 [here](https://github.com/bonzini/pinned-init/compare/cleanup-pre-stable...bonzini:pinned-init:stable).