### PR TITLE
Fix typos found by `checkpatch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ prefix.
 
 ## Examples
 
-Throught some examples we will make use of the `CMutex` type which can be found in
+Throughout some examples we will make use of the `CMutex` type which can be found in
 `../examples/mutex.rs`. It is essentially a rebuild of the `mutex` from the Linux kernel in userland. So
 it also uses a wait list and a basic spinlock. Importantly it needs to be pinned to be locked
 and thus is a prime candidate for using this library.

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -198,7 +198,7 @@ fn main() {
         );
     }
     for h in handles {
-        h.join().expect("thread paniced");
+        h.join().expect("thread panicked");
     }
     println!("{:?}", &*mtx.lock());
     assert_eq!(*mtx.lock(), workload * thread_count * 2);

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -168,7 +168,7 @@ fn main() {
             );
         }
         for h in handles {
-            h.join().expect("thread paniced");
+            h.join().expect("thread panicked");
         }
         println!("{:?}", &*mtx.lock());
         assert_eq!(*mtx.lock(), workload * thread_count * 2);

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -113,7 +113,7 @@ fn main() {
         );
     }
     for h in handles {
-        h.join().expect("thread paniced");
+        h.join().expect("thread panicked");
     }
     println!("{:?}, {:?}", &*mtx.lock(), &*COUNT.lock());
     assert_eq!(*mtx.lock(), workload * thread_count * 2);

--- a/pinned-init-macro/src/lib.rs
+++ b/pinned-init-macro/src/lib.rs
@@ -12,7 +12,7 @@ use proc_macro::TokenStream;
 /// field you want to have structurally pinned.
 ///
 /// This macro enables the use of the [`pin_init!`] macro. When pinned-initializing a `struct`,
-/// then `#[pin]` directs the type of intializer that is required.
+/// then `#[pin]` directs the type of initializer that is required.
 ///
 /// If your `struct` implements `Drop`, then you need to add `PinnedDrop` as arguments to this
 /// macro, and change your `Drop` implementation to `PinnedDrop` annotated with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //!
 //! # Examples
 //!
-//! Throught some examples we will make use of the `CMutex` type which can be found in
+//! Throughout some examples we will make use of the `CMutex` type which can be found in
 //! `../examples/mutex.rs`. It is essentially a rebuild of the `mutex` from the Linux kernel in userland. So
 //! it also uses a wait list and a basic spinlock. Importantly it needs to be pinned to be locked
 //! and thus is a prime candidate for using this library.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1248,7 +1248,7 @@ impl<T> InPlaceInit<T> for Arc<T> {
     {
         let mut this = try_new_uninit!(Arc);
         let Some(slot) = Arc::get_mut(&mut this) else {
-            // SAFETY: the Arc has just been created and has no external referecnes
+            // SAFETY: the Arc has just been created and has no external references
             unsafe { core::hint::unreachable_unchecked() }
         };
         let slot = slot.as_mut_ptr();
@@ -1266,7 +1266,7 @@ impl<T> InPlaceInit<T> for Arc<T> {
     {
         let mut this = try_new_uninit!(Arc);
         let Some(slot) = Arc::get_mut(&mut this) else {
-            // SAFETY: the Arc has just been created and has no external referecnes
+            // SAFETY: the Arc has just been created and has no external references
             unsafe { core::hint::unreachable_unchecked() }
         };
         let slot = slot.as_mut_ptr();


### PR DESCRIPTION
Found while running `checkpatch` against the future upstreaming
patches. So fix them here to begin with.

    ...:489: WARNING: 'paniced' may be misspelled - perhaps 'panicked'?
    ...:672: WARNING: 'paniced' may be misspelled - perhaps 'panicked'?
    ...:801: WARNING: 'paniced' may be misspelled - perhaps 'panicked'?

    ...:171: WARNING: 'referecnes' may be misspelled - perhaps 'references'?
    ...:189: WARNING: 'referecnes' may be misspelled - perhaps 'references'?

Plus a few more.

Please double-check if "Throughout" or "Through" would be best.