### PR TITLE
Dev/result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MaybeZeroable` derive macro to try to derive `Zeroable`, but not error if not all fields
   implement it.
 - `unsafe fn cast_[pin_]init()` functions to unsafely change the initialized type of an initializer
+- `impl<T, E> [Pin]Init<T, E> for Result<T, E>`, so results are now (pin-)initializers
 
 ### Changed
 
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added support for visibility in `Zeroable` derive macro
 - added support for `union`s in `Zeroable` derive macro
 - renamed the crate from `pinned-init` to `pin-init` and `pinned-init-macro` to `pin-init-internal`
+- blanket impls of `Init` and `PinInit` from `impl<T, E> [Pin]Init<T, E> for T` to
+  `impl<T> [Pin]Init<T> for T`
 
 ### Fixed
 

--- a/tests/ui/compile-fail/init/invalid_init.stderr
+++ b/tests/ui/compile-fail/init/invalid_init.stderr
@@ -10,5 +10,7 @@ error[E0277]: the trait bound `impl pin_init::PinInit<Bar>: Init<Bar>` is not sa
    | |______the trait `Init<Bar>` is not implemented for `impl pin_init::PinInit<Bar>`
    |        required by a bound introduced by this call
    |
-   = help: the trait `Init<T, E>` is implemented for `ChainInit<I, F, T, E>`
+   = help: the following other types implement trait `Init<T, E>`:
+             ChainInit<I, F, T, E>
+             Result<T, E>
    = note: this error originates in the macro `$crate::__init_internal` which comes from the expansion of the macro `init` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/compile-fail/pin_data/missing_pin.stderr
+++ b/tests/ui/compile-fail/pin_data/missing_pin.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `impl PinInit<usize>: Init<usize, _>` is not satis
    | |__________^ the trait `Init<usize, _>` is not implemented for `impl PinInit<usize>`
    |
    = help: the trait `Init<usize, _>` is not implemented for `impl PinInit<usize>`
-           but trait `Init<impl PinInit<usize>, _>` is implemented for it
+           but trait `Init<impl PinInit<usize>, Infallible>` is implemented for it
    = help: for that trait implementation, expected `impl PinInit<usize>`, found `usize`
 note: required by a bound in `__ThePinData::a`
   --> tests/ui/compile-fail/pin_data/missing_pin.rs:4:1


### PR DESCRIPTION
- change blanket impls of `Init` and `PinInit` from `impl<T, E> [Pin]Init<T, E> for E` to `impl<T> [Pin]Init<T> for T`
- add `impl<T, E> [Pin]Init<T, E> for Result<T, E>`, so results are now (pin-)initializers