### PR TITLE
fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > [!NOTE]
 > 
 > This crate was originally named [`pinned-init`], but the migration to
-> `pin-init` is not yet complete. The `legcay` branch contains the current
+> `pin-init` is not yet complete. The `legacy` branch contains the current
 > version of the `pinned-init` crate & the `main` branch already incorporates
 > the rename to `pin-init`.
 >


### PR DESCRIPTION
`s/legcay/legacy/` in the readme.

The irony is that I typo crap like this constantly, but aparently can spot it in others docs...