### PR TITLE
fix: silence some unneded warnings in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code at that point.
 - Make the `[try_][pin_]init!` macros expose initialized fields via a `let`
   binding as `&mut T` or `Pin<&mut T>` for later fields.
+- Silence warnings for edge cases like the projection being unused or struct members
+  start with underscore.
 
 ## [0.0.10] - 2025-08-19
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1005,6 +1005,7 @@ macro_rules! __pin_data {
     ) => {
         $crate::macros::paste! {
             #[doc(hidden)]
+            #[allow(dead_code)]
             $vis struct [< $name Projection >] <'__pin, $($decl_generics)*> {
                 $($(#[$($p_attr)*])* $pvis $p_field : ::core::pin::Pin<&'__pin mut $p_type>,)*
                 $($(#[$($attr)*])* $fvis $field : &'__pin mut $type,)*
@@ -1083,6 +1084,7 @@ macro_rules! __pin_data {
                 )*
                 $(
                     $(#[$($attr)*])*
+                    #[allow(non_snake_case)]
                     $fvis unsafe fn $field<E>(
                         self,
                         slot: *mut $type,
@@ -1093,6 +1095,7 @@ macro_rules! __pin_data {
                     }
 
                     $(#[$($attr)*])*
+                    #[allow(non_snake_case)]
                     $fvis unsafe fn [<__project_ $field>]<'__slot>(
                         self,
                         slot: &'__slot mut $type,

--- a/tests/ui/compile-fail/init/wrong_generics2.stderr
+++ b/tests/ui/compile-fail/init/wrong_generics2.stderr
@@ -12,7 +12,7 @@ help: you might have forgotten to add the struct literal inside the block
  --> src/macros.rs
   |
   ~                 ::core::ptr::write($slot, $t { SomeStruct {
-  |2                    $($acc)*
+  |5                    $($acc)*
   ~                 } });
   |
 

--- a/tests/ui/expand/many_generics.expanded.rs
+++ b/tests/ui/expand/many_generics.expanded.rs
@@ -13,6 +13,7 @@ where
     _pin: PhantomPinned,
 }
 #[doc(hidden)]
+#[allow(dead_code)]
 struct FooProjection<
     '__pin,
     'a,
@@ -97,6 +98,7 @@ const _: () = {
         ) -> ::core::pin::Pin<&'__slot mut PhantomPinned> {
             ::core::pin::Pin::new_unchecked(slot)
         }
+        #[allow(non_snake_case)]
         unsafe fn array<E>(
             self,
             slot: *mut [u8; 1024 * 1024],
@@ -104,12 +106,14 @@ const _: () = {
         ) -> ::core::result::Result<(), E> {
             unsafe { ::pin_init::Init::__init(init, slot) }
         }
+        #[allow(non_snake_case)]
         unsafe fn __project_array<'__slot>(
             self,
             slot: &'__slot mut [u8; 1024 * 1024],
         ) -> &'__slot mut [u8; 1024 * 1024] {
             slot
         }
+        #[allow(non_snake_case)]
         unsafe fn r<E>(
             self,
             slot: *mut &'b mut [&'a mut T; SIZE],
@@ -117,6 +121,7 @@ const _: () = {
         ) -> ::core::result::Result<(), E> {
             unsafe { ::pin_init::Init::__init(init, slot) }
         }
+        #[allow(non_snake_case)]
         unsafe fn __project_r<'__slot>(
             self,
             slot: &'__slot mut &'b mut [&'a mut T; SIZE],

--- a/tests/ui/expand/pin-data.expanded.rs
+++ b/tests/ui/expand/pin-data.expanded.rs
@@ -5,6 +5,7 @@ struct Foo {
     _pin: PhantomPinned,
 }
 #[doc(hidden)]
+#[allow(dead_code)]
 struct FooProjection<'__pin> {
     _pin: ::core::pin::Pin<&'__pin mut PhantomPinned>,
     array: &'__pin mut [u8; 1024 * 1024],
@@ -56,6 +57,7 @@ const _: () = {
         ) -> ::core::pin::Pin<&'__slot mut PhantomPinned> {
             ::core::pin::Pin::new_unchecked(slot)
         }
+        #[allow(non_snake_case)]
         unsafe fn array<E>(
             self,
             slot: *mut [u8; 1024 * 1024],
@@ -63,6 +65,7 @@ const _: () = {
         ) -> ::core::result::Result<(), E> {
             unsafe { ::pin_init::Init::__init(init, slot) }
         }
+        #[allow(non_snake_case)]
         unsafe fn __project_array<'__slot>(
             self,
             slot: &'__slot mut [u8; 1024 * 1024],

--- a/tests/ui/expand/pinned_drop.expanded.rs
+++ b/tests/ui/expand/pinned_drop.expanded.rs
@@ -5,6 +5,7 @@ struct Foo {
     _pin: PhantomPinned,
 }
 #[doc(hidden)]
+#[allow(dead_code)]
 struct FooProjection<'__pin> {
     _pin: ::core::pin::Pin<&'__pin mut PhantomPinned>,
     array: &'__pin mut [u8; 1024 * 1024],
@@ -56,6 +57,7 @@ const _: () = {
         ) -> ::core::pin::Pin<&'__slot mut PhantomPinned> {
             ::core::pin::Pin::new_unchecked(slot)
         }
+        #[allow(non_snake_case)]
         unsafe fn array<E>(
             self,
             slot: *mut [u8; 1024 * 1024],
@@ -63,6 +65,7 @@ const _: () = {
         ) -> ::core::result::Result<(), E> {
             unsafe { ::pin_init::Init::__init(init, slot) }
         }
+        #[allow(non_snake_case)]
         unsafe fn __project_array<'__slot>(
             self,
             slot: &'__slot mut [u8; 1024 * 1024],


### PR DESCRIPTION
1. When you are not using generated `project()` method, compiler warns about fields of the projection struct being never read.
2. If you have methods that start with underscore like `_marker: PhantomData<T>`, rust analyzer (not rustc) gives me `non_snake_case` warning. This is because of this internal method: `$fvis unsafe fn [<__project_ $field>]<'__slot>`. It uses `_` as a separator but `$field` may have it too.
