### PR TITLE
rust: pin-init: allow `dead_code` on projection structures

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1004,6 +1004,7 @@ macro_rules! __pin_data {
         @not_pinned($($(#[$($attr:tt)*])* $fvis:vis $field:ident : $type:ty),* $(,)?),
     ) => {
         $crate::macros::paste! {
+            #[allow(dead_code)]
             #[doc(hidden)]
             $vis struct [< $name Projection >] <'__pin, $($decl_generics)*> {
                 $($(#[$($p_attr)*])* $pvis $p_field : ::core::pin::Pin<&'__pin mut $p_type>,)*


### PR DESCRIPTION
Projection structures are not necessarily (and often not) used in their entirety. At the moment partial uses result in warnings about the unused members.

Discard them by allowing `dead_code` on the projection structure