### PR TITLE
build: simplify use of nightly features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ macrotest = "1.0"
 prettyplease = { version = "0.2.37", features = ["verbatim"] }
 
 [lints.rust]
+stable_features = "allow"
 non_ascii_idents = "deny"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(UI_TESTS)',

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,20 @@
-use rustc_version::{version, Version};
+use rustc_version::{version_meta, Channel, Version};
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(RUSTC_LINT_REASONS_IS_STABLE)");
-    println!("cargo::rustc-check-cfg=cfg(RUSTC_NEW_UNINIT_IS_STABLE)");
+    println!("cargo::rustc-check-cfg=cfg(USE_RUSTC_FEATURES)");
     println!("cargo::rustc-check-cfg=cfg(CONFIG_RUSTC_HAS_UNSAFE_PINNED)");
-    if version().unwrap() >= Version::parse("1.81.0").unwrap()
-        || version().unwrap() >= Version::parse("1.81.0-nightly").unwrap()
-    {
-        println!("cargo:rustc-cfg=RUSTC_LINT_REASONS_IS_STABLE");
+
+    let meta = version_meta().unwrap();
+
+    let use_feature = meta.channel == Channel::Nightly || std::env::var("RUSTC_BOOTSTRAP").is_ok();
+    if use_feature {
+        // Use this cfg option to control whether we should enable features that are already stable
+        // in some new Rust versions, but are available as unstable features in older Rust versions
+        // that needs to be supported by the Linux kernel.
+        println!("cargo:rustc-cfg=USE_RUSTC_FEATURES");
     }
-    if version().unwrap() >= Version::parse("1.82.0").unwrap() {
-        println!("cargo:rustc-cfg=RUSTC_NEW_UNINIT_IS_STABLE");
-    }
-    if version().unwrap() >= Version::parse("1.89.0-nightly").unwrap() {
+
+    if meta.semver >= Version::parse("1.89.0-nightly").unwrap() && use_feature {
         println!("cargo:rustc-cfg=CONFIG_RUSTC_HAS_UNSAFE_PINNED");
     }
 }

--- a/examples/big_struct_in_place.rs
+++ b/examples/big_struct_in_place.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::*;
 

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use core::{
     cell::Cell,

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 #![allow(clippy::missing_safety_doc)]
 
 use core::{

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -3,7 +3,7 @@
 // inspired by <https://github.com/nbdd0121/pin-init/blob/trunk/examples/pthread_mutex.rs>
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 #[cfg(not(windows))]
 mod pthread_mtx {

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 #![allow(unused_imports)]
 
 use core::{

--- a/internal/Cargo.toml
+++ b/internal/Cargo.toml
@@ -21,4 +21,5 @@ syn = { version = "2.0.86", features = ["full", "parsing", "visit-mut"] }
 rustc_version = "0.4"
 
 [lints.rust]
+stable_features = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kernel)'] }

--- a/internal/build.rs
+++ b/internal/build.rs
@@ -1,10 +1,12 @@
-use rustc_version::{version, Version};
+use rustc_version::{version_meta, Channel};
 
 fn main() {
-    println!("cargo::rustc-check-cfg=cfg(RUSTC_LINT_REASONS_IS_STABLE)");
-    if version().unwrap() >= Version::parse("1.81.0").unwrap()
-        || version().unwrap() >= Version::parse("1.81.0-nightly").unwrap()
-    {
-        println!("cargo:rustc-cfg=RUSTC_LINT_REASONS_IS_STABLE");
+    println!("cargo::rustc-check-cfg=cfg(USE_RUSTC_FEATURES)");
+
+    let meta = version_meta().unwrap();
+
+    let use_feature = meta.channel == Channel::Nightly || std::env::var("RUSTC_BOOTSTRAP").is_ok();
+    if use_feature {
+        println!("cargo:rustc-cfg=USE_RUSTC_FEATURES");
     }
 }

--- a/internal/src/lib.rs
+++ b/internal/src/lib.rs
@@ -6,7 +6,7 @@
 
 //! `pin-init` proc macros.
 
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 // Documentation is done in the pin-init crate instead.
 #![allow(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,12 +264,9 @@
 //! [`impl Init<T, E>`]: crate::Init
 //! [Rust-for-Linux]: https://rust-for-linux.com/
 
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 #![cfg_attr(
-    all(
-        any(feature = "alloc", feature = "std"),
-        not(RUSTC_NEW_UNINIT_IS_STABLE)
-    ),
+    all(any(feature = "alloc", feature = "std"), USE_RUSTC_FEATURES),
     feature(new_uninit)
 )]
 #![forbid(missing_docs, unsafe_op_in_unsafe_fn)]

--- a/tests/alloc_fail.rs
+++ b/tests/alloc_fail.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 #[test]
 #[cfg(feature = "alloc")]

--- a/tests/cfgs.rs
+++ b/tests/cfgs.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::{pin_data, pin_init, PinInit};
 

--- a/tests/const-generic-default.rs
+++ b/tests/const-generic-default.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::*;
 

--- a/tests/default_error.rs
+++ b/tests/default_error.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::{init, Init};
 

--- a/tests/init-scope.rs
+++ b/tests/init-scope.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::*;
 

--- a/tests/many_generics.rs
+++ b/tests/many_generics.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 #![allow(dead_code)]
 
 use core::{marker::PhantomPinned, pin::Pin};

--- a/tests/ring_buf.rs
+++ b/tests/ring_buf.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 #[test]
 #[cfg_attr(not(UI_TESTS), ignore)]

--- a/tests/ui/expand/many_generics.expanded.rs
+++ b/tests/ui/expand/many_generics.expanded.rs
@@ -1,4 +1,3 @@
-#![feature(lint_reasons)]
 #![allow(dead_code)]
 use core::{marker::PhantomPinned, pin::Pin};
 use pin_init::*;

--- a/tests/underscore.rs
+++ b/tests/underscore.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::{init, Init};
 

--- a/tests/zeroing.rs
+++ b/tests/zeroing.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use core::{marker::PhantomPinned, ptr::addr_of_mut};
 


### PR DESCRIPTION
Instead of check if a feature is already stable, simply enable them and allow the warning if the feature is already stable.

This avoids the need of the hardcoding whether a feature has been stabilized at a given version.

This should make the raw_ref_ops feature very easy to add.