### PR TITLE
refactor to use &raw mut

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ actually does the initialization in the correct way. Here are the things to look
 ```rust
 use pin_init::{pin_data, pinned_drop, PinInit, PinnedDrop, pin_init_from_closure};
 use core::{
-    ptr::addr_of_mut,
     marker::PhantomPinned,
     cell::UnsafeCell,
     pin::Pin,
@@ -199,7 +198,7 @@ impl RawFoo {
         unsafe {
             pin_init_from_closure(move |slot: *mut Self| {
                 // `slot` contains uninit memory, avoid creating a reference.
-                let foo = addr_of_mut!((*slot).foo);
+                let foo = &raw mut (*slot).foo;
                 let foo = UnsafeCell::raw_get(foo).cast::<bindings::foo>();
 
                 // Initialize the `foo`

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use rustc_version::{version_meta, Channel, Version};
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(USE_RUSTC_FEATURES)");
     println!("cargo::rustc-check-cfg=cfg(CONFIG_RUSTC_HAS_UNSAFE_PINNED)");
+    println!("cargo:rustc-check-cfg=cfg(RUSTC_RAW_REF_OP_IS_STABLE)");
 
     let meta = version_meta().unwrap();
 
@@ -16,5 +17,8 @@ fn main() {
 
     if meta.semver >= Version::parse("1.89.0-nightly").unwrap() && use_feature {
         println!("cargo:rustc-cfg=CONFIG_RUSTC_HAS_UNSAFE_PINNED");
+    }
+    if meta.semver >= Version::parse("1.82.0").unwrap() && use_feature {
+        println!("cargo:rustc-cfg=RUSTC_RAW_REF_OP_IS_STABLE");
     }
 }

--- a/examples/big_struct_in_place.rs
+++ b/examples/big_struct_in_place.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use pin_init::*;
 

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use core::{
     cell::Cell,

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![allow(clippy::missing_safety_doc)]
 
 use core::{

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 #[cfg(not(windows))]
 mod pthread_mtx {

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![allow(unused_imports)]
 
 use core::{

--- a/internal/src/init.rs
+++ b/internal/src/init.rs
@@ -290,7 +290,7 @@ fn init_fields(
                     {
                         #value_prep
                         // SAFETY: TODO
-                        unsafe { #write(::core::ptr::addr_of_mut!((*#slot).#ident), #value_ident) };
+                        unsafe { #write(&raw mut (*#slot).#ident, #value_ident) };
                     }
                     #accessor
                 }
@@ -307,7 +307,7 @@ fn init_fields(
                             //   return when an error/panic occurs.
                             // - We also use `#data` to require the correct trait (`Init` or `PinInit`)
                             //   for `#ident`.
-                            unsafe { #data.#ident(::core::ptr::addr_of_mut!((*#slot).#ident), #init)? };
+                            unsafe { #data.#ident(&raw mut (*#slot).#ident, #init)? };
                         },
                         quote! {
                             // SAFETY: TODO
@@ -322,7 +322,7 @@ fn init_fields(
                             unsafe {
                                 ::pin_init::Init::__init(
                                     #init,
-                                    ::core::ptr::addr_of_mut!((*#slot).#ident),
+                                    &raw mut (*#slot).#ident,
                                 )?
                             };
                         },
@@ -367,7 +367,7 @@ fn init_fields(
                 // SAFETY: We forget the guard later when initialization has succeeded.
                 let #guard = unsafe {
                     ::pin_init::__internal::DropGuard::new(
-                        ::core::ptr::addr_of_mut!((*slot).#ident)
+                        &raw mut (*slot).#ident
                     )
                 };
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,6 @@
 //! # #![feature(extern_types)]
 //! use pin_init::{pin_data, pinned_drop, PinInit, PinnedDrop, pin_init_from_closure};
 //! use core::{
-//!     ptr::addr_of_mut,
 //!     marker::PhantomPinned,
 //!     cell::UnsafeCell,
 //!     pin::Pin,
@@ -211,7 +210,7 @@
 //!         unsafe {
 //!             pin_init_from_closure(move |slot: *mut Self| {
 //!                 // `slot` contains uninit memory, avoid creating a reference.
-//!                 let foo = addr_of_mut!((*slot).foo);
+//!                 let foo = &raw mut (*slot).foo;
 //!                 let foo = UnsafeCell::raw_get(foo).cast::<bindings::foo>();
 //!
 //!                 // Initialize the `foo`
@@ -265,6 +264,7 @@
 //! [Rust-for-Linux]: https://rust-for-linux.com/
 
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![cfg_attr(
     all(any(feature = "alloc", feature = "std"), USE_RUSTC_FEATURES),
     feature(new_uninit)
@@ -754,7 +754,7 @@ macro_rules! stack_try_pin_init {
 ///
 /// ```rust
 /// # use pin_init::*;
-/// # use core::{ptr::addr_of_mut, marker::PhantomPinned};
+/// # use core::marker::PhantomPinned;
 /// #[pin_data]
 /// #[derive(Zeroable)]
 /// struct Buf {
@@ -768,7 +768,7 @@ macro_rules! stack_try_pin_init {
 /// let init = pin_init!(&this in Buf {
 ///     buf: [0; 64],
 ///     // SAFETY: TODO.
-///     ptr: unsafe { addr_of_mut!((*this.as_ptr()).buf).cast() },
+///     ptr: unsafe { (&raw mut (*this.as_ptr()).buf).cast() },
 ///     pin: PhantomPinned,
 /// });
 /// let init = pin_init!(Buf {

--- a/tests/cfgs.rs
+++ b/tests/cfgs.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use pin_init::{pin_data, pin_init, PinInit};
 

--- a/tests/const-generic-default.rs
+++ b/tests/const-generic-default.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use pin_init::*;
 

--- a/tests/init-scope.rs
+++ b/tests/init-scope.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use pin_init::*;
 

--- a/tests/ring_buf.rs
+++ b/tests/ring_buf.rs
@@ -1,16 +1,11 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::sync::Arc;
-use core::{
-    convert::Infallible,
-    marker::PhantomPinned,
-    mem::MaybeUninit,
-    pin::Pin,
-    ptr::{self, addr_of_mut},
-};
+use core::{convert::Infallible, marker::PhantomPinned, mem::MaybeUninit, pin::Pin, ptr};
 use pin_init::*;
 #[cfg(feature = "std")]
 use std::sync::Arc;
@@ -50,8 +45,8 @@ impl<T, const SIZE: usize> RingBuffer<T, SIZE> {
             // SAFETY: The elements of the array can be uninitialized.
             buffer <- unsafe { init_from_closure(|_| Ok::<_, Infallible>(())) },
             // SAFETY: `this` is a valid pointer.
-            head: unsafe { addr_of_mut!((*this.as_ptr()).buffer).cast::<T>() },
-            tail: unsafe { addr_of_mut!((*this.as_ptr()).buffer).cast::<T>() },
+            head: unsafe { (&raw mut (*this.as_ptr()).buffer).cast::<T>() },
+            tail: unsafe { (&raw mut (*this.as_ptr()).buffer).cast::<T>() },
             _pin: PhantomPinned,
         })
     }
@@ -112,7 +107,7 @@ impl<T, const SIZE: usize> RingBuffer<T, SIZE> {
     unsafe fn advance(&mut self, ptr: *mut T) -> *mut T {
         // SAFETY: ptr's offset from buffer is < SIZE
         let ptr = unsafe { ptr.add(1) };
-        let origin: *mut _ = addr_of_mut!(self.buffer);
+        let origin: *mut _ = &raw mut (self.buffer);
         let origin = origin.cast::<T>();
         let offset = unsafe { ptr.offset_from(origin) };
         if offset >= SIZE as isize {

--- a/tests/underscore.rs
+++ b/tests/underscore.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use pin_init::{init, Init};
 

--- a/tests/zeroing.rs
+++ b/tests/zeroing.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
-use core::{marker::PhantomPinned, ptr::addr_of_mut};
+use std::marker::PhantomPinned;
 
 use pin_init::*;
 
@@ -22,7 +23,7 @@ impl Foo {
             marks: {
                 let ptr = this.as_ptr();
                 // SAFETY: project from the NonNull<Foo> to the buf field
-                let ptr = unsafe { addr_of_mut!((*ptr).buf) }.cast::<u8>();
+                let ptr = unsafe { &raw mut (*ptr).buf }.cast::<u8>();
                 [ptr; MARKS]},
             ..Zeroable::init_zeroed()
         })


### PR DESCRIPTION
Replacing all occurrences of addr_of_mut!(place) with &raw mut place.

This will allow us to reduce macro complexity, and improve consistency with existing reference syntax as &raw mut is similar to &mut making it fit more naturally with other existing code.

NOTE: A alternative version of #49, but based on #102
