### PR TITLE
properly document let binding workaround

### DIFF
--- a/examples/big_struct_in_place.rs
+++ b/examples/big_struct_in_place.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+
 use pin_init::*;
 
 // Struct with size over 1GiB

--- a/internal/src/init.rs
+++ b/internal/src/init.rs
@@ -189,6 +189,12 @@ pub(crate) fn expand(
         };
         // SAFETY: TODO
         let init = unsafe { ::pin_init::#init_from_closure::<_, #error>(init) };
+        // FIXME: this let binding is required to avoid a compiler error (cycle when computing the
+        // opaque type returned by this function) before Rust 1.81. Remove after MSRV bump.
+        #[allow(
+            clippy::let_and_return,
+            reason = "some clippy versions warn about the let binding"
+        )]
         init
     }})
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1147,9 +1147,12 @@ pub const unsafe fn cast_pin_init<T, U, E>(init: impl PinInit<T, E>) -> impl Pin
     // SAFETY: initialization delegated to a valid initializer. Cast is valid by function safety
     // requirements.
     let res = unsafe { pin_init_from_closure(|ptr: *mut U| init.__pinned_init(ptr.cast::<T>())) };
-    // FIXME: remove the let statement once the nightly-MSRV allows it (1.78 otherwise encounters a
-    // cycle when computing the type returned by this function)
-    #[allow(clippy::let_and_return)]
+    // FIXME: this let binding is required to avoid a compiler error (cycle when computing the opaque
+    // type returned by this function) before Rust 1.81. Remove after MSRV bump.
+    #[allow(
+        clippy::let_and_return,
+        reason = "some clippy versions warn about the let binding"
+    )]
     res
 }
 
@@ -1163,9 +1166,12 @@ pub const unsafe fn cast_init<T, U, E>(init: impl Init<T, E>) -> impl Init<U, E>
     // SAFETY: initialization delegated to a valid initializer. Cast is valid by function safety
     // requirements.
     let res = unsafe { init_from_closure(|ptr: *mut U| init.__init(ptr.cast::<T>())) };
-    // FIXME: remove the let statement once the nightly-MSRV allows it (1.78 otherwise encounters a
-    // cycle when computing the type returned by this function)
-    #[allow(clippy::let_and_return)]
+    // FIXME: this let binding is required to avoid a compiler error (cycle when computing the opaque
+    // type returned by this function) before Rust 1.81. Remove after MSRV bump.
+    #[allow(
+        clippy::let_and_return,
+        reason = "some clippy versions warn about the let binding"
+    )]
     res
 }
 

--- a/tests/default_error.rs
+++ b/tests/default_error.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
 
 use pin_init::{init, Init};
 

--- a/tests/ui/expand/no_field_access.expanded.rs
+++ b/tests/ui/expand/no_field_access.expanded.rs
@@ -68,6 +68,9 @@ fn main() {
         let init = unsafe {
             ::pin_init::init_from_closure::<_, ::core::convert::Infallible>(init)
         };
-        init
+        #[allow(
+            clippy::let_and_return,
+            reason = "some clippy versions warn about the let binding"
+        )] init
     };
 }

--- a/tests/ui/expand/simple-init.expanded.rs
+++ b/tests/ui/expand/simple-init.expanded.rs
@@ -30,6 +30,9 @@ fn main() {
         let init = unsafe {
             ::pin_init::init_from_closure::<_, ::core::convert::Infallible>(init)
         };
-        init
+        #[allow(
+            clippy::let_and_return,
+            reason = "some clippy versions warn about the let binding"
+        )] init
     };
 }

--- a/tests/underscore.rs
+++ b/tests/underscore.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(RUSTC_LINT_REASONS_IS_STABLE), feature(lint_reasons))]
+
 use pin_init::{init, Init};
 
 pub struct Foo {


### PR DESCRIPTION
The three let bindings (in the bodies of `cast_init`, `cast_pin_init` and the `init!` macro) are used to avoid the following compiler error in Rust 1.78.0, 1.79.0, 1.80.0, 1.80.1, and 1.81.0 (just showing the one for `cast_init`, the others are similar):

    error[E0391]: cycle detected when computing type of opaque `cast_init::{opaque#0}`
        --> src/lib.rs:1160:66
         |
    1160 | pub const unsafe fn cast_init<T, U, E>(init: impl Init<T, E>) -> impl Init<U, E> {
         |                                                                  ^^^^^^^^^^^^^^^
         |
    note: ...which requires borrow-checking `cast_init`...
        --> src/lib.rs:1160:1
         |
    1160 | pub const unsafe fn cast_init<T, U, E>(init: impl Init<T, E>) -> impl Init<U, E> {
         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    note: ...which requires const checking `cast_init`...
        --> src/lib.rs:1160:1
         |
    1160 | pub const unsafe fn cast_init<T, U, E>(init: impl Init<T, E>) -> impl Init<U, E> {
         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         = note: ...which requires computing whether `cast_init::{opaque#0}` is freeze...
         = note: ...which requires evaluating trait selection obligation `cast_init::{opaque#0}: core::marker::Freeze`...
         = note: ...which again requires computing type of opaque `cast_init::{opaque#0}`, completing the cycle
    note: cycle used when computing type of `cast_init::{opaque#0}`
        --> src/lib.rs:1160:66
         |
    1160 | pub const unsafe fn cast_init<T, U, E>(init: impl Init<T, E>) -> impl Init<U, E> {
         |                                                                  ^^^^^^^^^^^^^^^
         = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information

Once we raise the nightly-MSRV above 1.81, we can remove this workaround.