### PR TITLE
allow `unused_features` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ prettyplease = { version = "0.2.37", features = ["verbatim"] }
 
 [lints.rust]
 stable_features = "allow"
+unused_features = "allow"
 non_ascii_idents = "deny"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(UI_TESTS)',

--- a/internal/Cargo.toml
+++ b/internal/Cargo.toml
@@ -22,4 +22,5 @@ rustc_version = "0.4"
 
 [lints.rust]
 stable_features = "allow"
+unused_features = "allow"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kernel)'] }


### PR DESCRIPTION
The `unused_features` lint was introduced in https://github.com/rust-lang/rust/pull/152164, presumably landing in Rust 1.96.0. We simplified the way we use features in #102, always enabling them when building the crate with certain features enabled. For this reason allow the lint.

I plan to also add a new CI run that enables the lint & checks if we can remove certain features. Will do so at a later point in time.

This PR fixes the CI failure observed in https://github.com/Rust-for-Linux/pin-init/actions/runs/22754182535