### PR TITLE
Cleanup `Zeroable` and `ZeroableOptions`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1517,27 +1517,6 @@ pub unsafe trait Zeroable {
     }
 }
 
-/// Marker trait for types that allow `Option<Self>` to be set to all zeroes in order to write
-/// `None` to that location.
-///
-/// # Safety
-///
-/// The implementer needs to ensure that `unsafe impl Zeroable for Option<Self> {}` is sound.
-pub unsafe trait ZeroableOption {}
-
-// SAFETY: by the safety requirement of `ZeroableOption`, this is valid.
-unsafe impl<T: ZeroableOption> Zeroable for Option<T> {}
-
-// SAFETY: `Option<&T>` is part of the option layout optimization guarantee:
-// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-unsafe impl<T> ZeroableOption for &T {}
-// SAFETY: `Option<&mut T>` is part of the option layout optimization guarantee:
-// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-unsafe impl<T> ZeroableOption for &mut T {}
-// SAFETY: `Option<NonNull<T>>` is part of the option layout optimization guarantee:
-// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-unsafe impl<T> ZeroableOption for NonNull<T> {}
-
 /// Create an initializer for a zeroed `T`.
 ///
 /// The returned initializer will write `0x00` to every byte of the given `slot`.
@@ -1643,6 +1622,27 @@ macro_rules! impl_tuple_zeroable {
 
 impl_tuple_zeroable!(A, B, C, D, E, F, G, H, I, J);
 
+/// Marker trait for types that allow `Option<Self>` to be set to all zeroes in order to write
+/// `None` to that location.
+///
+/// # Safety
+///
+/// The implementer needs to ensure that `unsafe impl Zeroable for Option<Self> {}` is sound.
+pub unsafe trait ZeroableOption {}
+
+// SAFETY: by the safety requirement of `ZeroableOption`, this is valid.
+unsafe impl<T: ZeroableOption> Zeroable for Option<T> {}
+
+// SAFETY: `Option<&T>` is part of the option layout optimization guarantee:
+// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
+unsafe impl<T> ZeroableOption for &T {}
+// SAFETY: `Option<&mut T>` is part of the option layout optimization guarantee:
+// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
+unsafe impl<T> ZeroableOption for &mut T {}
+// SAFETY: `Option<NonNull<T>>` is part of the option layout optimization guarantee:
+// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
+unsafe impl<T> ZeroableOption for NonNull<T> {}
+
 macro_rules! impl_fn_zeroable_option {
     ([$($abi:literal),* $(,)?] $args:tt) => {
         $(impl_fn_zeroable_option!({extern $abi} $args);)*
@@ -1668,14 +1668,14 @@ macro_rules! impl_fn_zeroable_option {
 
 impl_fn_zeroable_option!(["Rust", "C"] { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U });
 
-macro_rules! impl_non_zero_int_zeroable_option {
+macro_rules! impl_zeroable_option {
     ($($int:ty),* $(,)?) => {
         // SAFETY: Safety comment written in the macro invocation.
         $(unsafe impl ZeroableOption for $int {})*
     };
 }
 
-impl_non_zero_int_zeroable_option! {
+impl_zeroable_option! {
     // SAFETY: All zeros is equivalent to `None` (option layout optimization guarantee:
     // <https://doc.rust-lang.org/stable/std/option/index.html#representation>).
     NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1633,16 +1633,6 @@ pub unsafe trait ZeroableOption {}
 // SAFETY: by the safety requirement of `ZeroableOption`, this is valid.
 unsafe impl<T: ZeroableOption> Zeroable for Option<T> {}
 
-// SAFETY: `Option<&T>` is part of the option layout optimization guarantee:
-// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-unsafe impl<T> ZeroableOption for &T {}
-// SAFETY: `Option<&mut T>` is part of the option layout optimization guarantee:
-// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-unsafe impl<T> ZeroableOption for &mut T {}
-// SAFETY: `Option<NonNull<T>>` is part of the option layout optimization guarantee:
-// <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-unsafe impl<T> ZeroableOption for NonNull<T> {}
-
 macro_rules! impl_fn_zeroable_option {
     ([$($abi:literal),* $(,)?] $args:tt) => {
         $(impl_fn_zeroable_option!({extern $abi} $args);)*
@@ -1669,17 +1659,26 @@ macro_rules! impl_fn_zeroable_option {
 impl_fn_zeroable_option!(["Rust", "C"] { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U });
 
 macro_rules! impl_zeroable_option {
-    ($($int:ty),* $(,)?) => {
-        // SAFETY: Safety comment written in the macro invocation.
-        $(unsafe impl ZeroableOption for $int {})*
+    ($($({$($generics:tt)*})? $t:ty, )*) => {
+        // SAFETY: Safety comments written in the macro invocation.
+        $(unsafe impl$($($generics)*)? ZeroableOption for $t {})*
     };
 }
 
 impl_zeroable_option! {
+    // SAFETY: `Option<&T>` is part of the option layout optimization guarantee:
+    // <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
+    {<T: ?Sized>} &T,
+    // SAFETY: `Option<&mut T>` is part of the option layout optimization guarantee:
+    // <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
+    {<T: ?Sized>} &mut T,
+    // SAFETY: `Option<NonNull<T>>` is part of the option layout optimization guarantee:
+    // <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
+    {<T: ?Sized>} NonNull<T>,
     // SAFETY: All zeros is equivalent to `None` (option layout optimization guarantee:
     // <https://doc.rust-lang.org/stable/std/option/index.html#representation>).
-    NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroUsize,
-    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize,
+    NonZero<u8>, NonZero<u16>, NonZero<u32>, NonZero<u64>, NonZero<u128>, NonZero<usize>,
+    NonZero<i8>, NonZero<i16>, NonZero<i32>, NonZero<i64>, NonZero<i128>, NonZero<isize>,
 }
 
 /// This trait allows creating an instance of `Self` which contains exactly one

--- a/tests/ui/compile-fail/zeroable/option_string_not_zeroable.rs
+++ b/tests/ui/compile-fail/zeroable/option_string_not_zeroable.rs
@@ -1,0 +1,8 @@
+use pin_init::*;
+
+#[derive(Zeroable)]
+struct Foo {
+    x: Option<String>,
+}
+
+fn main() {}

--- a/tests/ui/compile-fail/zeroable/option_string_not_zeroable.stderr
+++ b/tests/ui/compile-fail/zeroable/option_string_not_zeroable.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `String: ZeroableOption` is not satisfied
+ --> tests/ui/compile-fail/zeroable/option_string_not_zeroable.rs:5:8
+  |
+5 |     x: Option<String>,
+  |        ^^^^^^^^^^^^^^ the trait `ZeroableOption` is not implemented for `String`
+  |
+  = help: the following other types implement trait `ZeroableOption`:
+            &T
+            &mut T
+            Box<T>
+            NonNull<T>
+            NonZero<i128>
+            NonZero<i16>
+            NonZero<i32>
+            NonZero<i64>
+          and $N others
+  = note: required for `Option<String>` to implement `pin_init::Zeroable`
+note: required by a bound in `assert_zeroable`
+ --> tests/ui/compile-fail/zeroable/option_string_not_zeroable.rs:3:10
+  |
+3 | #[derive(Zeroable)]
+  |          ^^^^^^^^ required by this bound in `assert_zeroable`
+  = note: this error originates in the derive macro `Zeroable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/zeroing.rs
+++ b/tests/zeroing.rs
@@ -1,5 +1,9 @@
 use std::marker::PhantomPinned;
 
+use core::{
+    num::{NonZeroI32, NonZeroU8, NonZeroUsize},
+    ptr::NonNull,
+};
 use pin_init::*;
 
 const MARKS: usize = 64;
@@ -31,4 +35,31 @@ impl Foo {
 #[cfg(any(feature = "std", feature = "alloc"))]
 fn test() {
     let _ = Box::pin_init(Foo::new()).unwrap();
+}
+
+#[test]
+fn zeroed_option_runtime_values() {
+    let ref_opt: Option<&u8> = zeroed();
+    let mut_ref_opt: Option<&mut u8> = zeroed();
+    let non_null_opt: Option<NonNull<u8>> = zeroed();
+    let non_zero_unsigned: Option<NonZeroUsize> = zeroed();
+    let non_zero_signed: Option<NonZeroI32> = zeroed();
+
+    assert!(ref_opt.is_none());
+    assert!(mut_ref_opt.is_none());
+    assert!(non_null_opt.is_none());
+    assert!(non_zero_unsigned.is_none());
+    assert!(non_zero_signed.is_none());
+}
+
+fn assert_zeroable_option<T: ZeroableOption>() {
+    let _: Option<T> = zeroed();
+}
+
+#[test]
+fn zeroed_option_generic_compile_check() {
+    assert_zeroable_option::<&u8>();
+    assert_zeroable_option::<&mut u8>();
+    assert_zeroable_option::<NonNull<u8>>();
+    assert_zeroable_option::<NonZeroU8>();
 }


### PR DESCRIPTION
Did my part of janitor work to help cleanup `Zeroable` and `ZeroableOption` as suggested in #116:

- [x]  Ensure consistency in placement: put the `Zeroable` trait and its implementations (including macro invocations) first in the relevant section of `src/lib.rs`, followed by the `ZeroableOption` trait and its implementations.
- [x] One of the macros is currently named `impl_non_zero_int_zeroable_option`; it should be renamed to `impl_zeroable_option` for consistency.
- [x] Use the `impl_zeroable_option` macro to handle generic impls for types like `&T`, `&mut T`, `NonNull<T>`, and others (for which `Option<T>` is guaranteed to be zeroable). 

Added an extra commit for minimal testing which I'm not sure how helpful it is but feel free to not include:
- `tests/zeroing.rs` coverage that `zeroed::<Option<T>>()` is `None` for refs, `NonNull`, and nonzero ints.
- generic compile-check coverage for `T: ZeroableOption` (`&u8`, `&mut u8`, `NonNull<u8>`, `NonZeroU8`).
- UI compile-fail test `zeroable/option_string_not_zeroable.rs` to verify `Option<String>` is not `Zeroable`.

Closes: #116 