### PR TITLE
internal: error on duplicate `#[pin]` attribute

### DIFF
--- a/internal/src/pin_data.rs
+++ b/internal/src/pin_data.rs
@@ -85,7 +85,10 @@ pub(crate) fn pin_data(
         .map(|field| {
             let len = field.attrs.len();
             field.attrs.retain(|a| !a.path().is_ident("pin"));
-            let pinned = len != field.attrs.len();
+            let pinned_count = len - field.attrs.len();
+            if pinned_count > 1 {
+                dcx.error(&field, "#[pin] attribute specified more than once");
+            }
 
             let cfg_attrs = field
                 .attrs
@@ -95,7 +98,7 @@ pub(crate) fn pin_data(
 
             FieldInfo {
                 field: &*field,
-                pinned,
+                pinned: pinned_count != 0,
                 cfg_attrs,
             }
         })

--- a/tests/ui/compile-fail/pin_data/twice_pin.rs
+++ b/tests/ui/compile-fail/pin_data/twice_pin.rs
@@ -1,0 +1,12 @@
+use pin_init::*;
+
+#[pin_data]
+struct Foo {
+    #[pin]
+    #[pin]
+    a: usize,
+}
+
+fn main() {
+    let _ = pin_init!(Foo { a: 1 });
+}

--- a/tests/ui/compile-fail/pin_data/twice_pin.stderr
+++ b/tests/ui/compile-fail/pin_data/twice_pin.stderr
@@ -1,0 +1,5 @@
+error: #[pin] attribute specified more than once
+ --> tests/ui/compile-fail/pin_data/twice_pin.rs:7:5
+  |
+7 |     a: usize,
+  |     ^^^^^^^^


### PR DESCRIPTION
adds the error and a compile_fail test to check for it.

Closes: https://github.com/Rust-for-Linux/pin-init/issues/119