### PR TITLE
internal: add missing where clause to projection types

### DIFF
--- a/internal/src/pin_data.rs
+++ b/internal/src/pin_data.rs
@@ -304,7 +304,9 @@ fn generate_projections(
         #[doc = #docs]
         #[allow(dead_code)]
         #[doc(hidden)]
-        #vis struct #projection #generics_with_pin_lt {
+        #vis struct #projection #generics_with_pin_lt
+            #whr
+        {
             #(#fields_decl)*
             ___pin_phantom_data: ::core::marker::PhantomData<&'__pin mut ()>,
         }

--- a/tests/ui/expand/many_generics.expanded.rs
+++ b/tests/ui/expand/many_generics.expanded.rs
@@ -15,13 +15,10 @@ where
 /// Pin-projections of [`Foo`]
 #[allow(dead_code)]
 #[doc(hidden)]
-struct FooProjection<
-    '__pin,
-    'a,
-    'b: 'a,
-    T: Bar<'b> + ?Sized + 'a,
-    const SIZE: usize = 0,
-> {
+struct FooProjection<'__pin, 'a, 'b: 'a, T: Bar<'b> + ?Sized + 'a, const SIZE: usize = 0>
+where
+    T: Bar<'a, 1>,
+{
     array: &'__pin mut [u8; 1024 * 1024],
     r: &'__pin mut &'b mut [&'a mut T; SIZE],
     _pin: ::core::pin::Pin<&'__pin mut PhantomPinned>,

--- a/tests/where_bounds.rs
+++ b/tests/where_bounds.rs
@@ -1,0 +1,61 @@
+use core::marker::PhantomData;
+use pin_init::*;
+
+struct Queue<T: Iterator<Item = u8> + 'static> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Iterator<Item = u8> + 'static> Queue<T> {
+    fn new() -> impl PinInit<Self> {
+        init!(Self {
+            _marker: PhantomData,
+        })
+    }
+}
+
+#[pin_data]
+struct InlineBoundHandler<T: Iterator<Item = u8> + 'static> {
+    #[pin]
+    queue: Queue<T>,
+}
+
+impl<T: Iterator<Item = u8> + 'static> InlineBoundHandler<T> {
+    fn new() -> impl PinInit<Self> {
+        pin_init!(Self {
+            queue <- Queue::new(),
+        })
+    }
+}
+
+#[pin_data]
+struct WhereBoundHandler<T>
+where
+    T: Iterator<Item = u8> + 'static,
+{
+    #[pin]
+    queue: Queue<T>,
+}
+
+impl<T> WhereBoundHandler<T>
+where
+    T: Iterator<Item = u8> + 'static,
+{
+    fn new() -> impl PinInit<Self> {
+        pin_init!(Self {
+            queue <- Queue::new(),
+        })
+    }
+}
+
+#[test]
+fn pin_data_preserves_inline_and_where_bounds() {
+    type Iter = core::iter::Empty<u8>;
+
+    stack_pin_init!(let inline = InlineBoundHandler::<Iter>::new());
+    let inline_proj = inline.as_mut().project();
+    let _ = inline_proj.queue;
+
+    stack_pin_init!(let where_ = WhereBoundHandler::<Iter>::new());
+    let where_proj = where_.as_mut().project();
+    let _ = where_proj.queue;
+}


### PR DESCRIPTION
`#[pin_data]` failed to propagate the struct's `where` clause to the generated projection struct. As a result, bounds written in a `where` clause could be dropped during expansion, causing type errors when fields depended on those bounds.

Fix this by adding the missing `where` clause to the generated projection struct.

Add a regression test covering `#[pin_data]` with `where`-clause bounds.

Bless expand tests (only `many_generics.rs`) that became outdated.

Link: https://rust-for-linux.zulipchat.com/#narrow/channel/561532-pin-init/topic/generic.20bounds.20and.20.60.23.5Bpin_data.5D.60/with/578381591
Reported-by: Andreas Hindborg <a.hindborg@kernel.org>