### PR TITLE
reorder safety comments and attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1640,8 +1640,8 @@ macro_rules! impl_tuple_zeroable {
         unsafe impl<$first: Zeroable> Zeroable for ($first,) {}
     };
     ($first:ident, $($t:ident),* $(,)?) => {
-        // SAFETY: All elements are zeroable and padding can be zero.
         #[cfg_attr(doc, doc(hidden))]
+        // SAFETY: All elements are zeroable and padding can be zero.
         unsafe impl<$first: Zeroable, $($t: Zeroable),*> Zeroable for ($first, $($t),*) {}
         impl_tuple_zeroable!($($t),* ,);
     }
@@ -1664,9 +1664,9 @@ macro_rules! impl_fn_zeroable_option {
         impl_fn_zeroable_option!({$($prefix)*} {$arg,});
     };
     ({$($prefix:tt)*} {$ret:ident, $($rest:ident),* $(,)?}) => {
+        #[cfg_attr(doc, doc(hidden))]
         // SAFETY: function pointers are part of the option layout optimization:
         // <https://doc.rust-lang.org/stable/std/option/index.html#representation>.
-        #[cfg_attr(doc, doc(hidden))]
         unsafe impl<$ret, $($rest),*> ZeroableOption for $($prefix)* fn($($rest),*) -> $ret {}
         impl_fn_zeroable_option!({$($prefix)*} {$($rest),*,});
     };


### PR DESCRIPTION
This avoids clippy errors in old versions of clippy (here 1.78):

    error: unsafe impl missing a safety comment
        --> src/lib.rs:1677:9
         |
    1677 |         unsafe impl<$ret, $($rest),*> ZeroableOption for $($prefix)* fn($($rest),*) -> $ret {}
         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...
    1682 | impl_fn_zeroable_option!(["Rust", "C"] { A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U });
         | --------------------------------------------------------------------------------------------------------- in this macro invocation
         |
         = help: consider adding a safety comment on the preceding line
         = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#undocumented_unsafe_blocks
         = note: this error originates in the macro `impl_fn_zeroable_option` (in Nightly builds, run with -Z macro-backtrace for more info)

Fixes: 530c4eb79a44 ("doc: de-clutter documentation with fake-variadics")