### PR TITLE
build.rs: remove unstable feature handling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@ use rustc_version::{version_meta, Channel, Version};
 fn main() {
     println!("cargo::rustc-check-cfg=cfg(USE_RUSTC_FEATURES)");
     println!("cargo::rustc-check-cfg=cfg(CONFIG_RUSTC_HAS_UNSAFE_PINNED)");
-    println!("cargo:rustc-check-cfg=cfg(RUSTC_RAW_REF_OP_IS_STABLE)");
 
     let meta = version_meta().unwrap();
 
@@ -17,8 +16,5 @@ fn main() {
 
     if meta.semver >= Version::parse("1.89.0-nightly").unwrap() && use_feature {
         println!("cargo:rustc-cfg=CONFIG_RUSTC_HAS_UNSAFE_PINNED");
-    }
-    if meta.semver >= Version::parse("1.82.0").unwrap() && use_feature {
-        println!("cargo:rustc-cfg=RUSTC_RAW_REF_OP_IS_STABLE");
     }
 }


### PR DESCRIPTION
Commit 885c5d83d7eb ("build: simplify use of nightly features") removed the need to track each unstable feature individually. The raw_ref_op cfgs were added in commit e27763004e2f ("replace `addr_of_mut!` with `&raw mut`"), which was rebased and the parts in build.rs were forgotten.

Fixes: e27763004e2f ("replace `addr_of_mut!` with `&raw mut`")