### PR TITLE
examples: mark as `#[inline]` all `From::from()`s for `Error`

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -11,6 +11,7 @@ use std::alloc::AllocError;
 pub struct Error;
 
 impl From<Infallible> for Error {
+    #[inline]
     fn from(e: Infallible) -> Self {
         match e {}
     }
@@ -18,6 +19,7 @@ impl From<Infallible> for Error {
 
 #[cfg(feature = "alloc")]
 impl From<AllocError> for Error {
+    #[inline]
     fn from(_: AllocError) -> Self {
         Self
     }


### PR DESCRIPTION
There was a recent request [1] to mark as `#[inline]` the simple
`From::from()` functions implemented for `Error`.

Thus mark all of the existing

```
    impl From<...> for Error {
        fn from(err: ...) -> Self {
            ...
        }
    }
```

functions in the `kernel` crate as `#[inline]`.

Suggested-by: Gary Guo <gary@garyguo.net>
Link: https://lore.kernel.org/all/8403c8b7a832b5274743816eb77abfa4@garyguo.net/ [1]
