### PR TITLE
init: allow `nonstandard_style` for generated accessor/value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrected `T: Sized` bounds to `T: ?Sized` in the generated `PinnedDrop`
   check by `#[pin_data]`.
+- `#[pin_data]` no longer produces additional `non_snake_case` warnings if field names
+  are not of snake case. Standard field definition warnings are unaffected.
 
 ## [0.0.10] - 2025-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check by `#[pin_data]`.
 - `#[pin_data]` no longer produces additional `non_snake_case` warnings if field names
   are not of snake case. Standard field definition warnings are unaffected.
+- `init!` and `pin_init!` no longer produce `non_snake_case` warnings if field names
+  are not of snake case. Warnings on the struct definition are unaffected.
 
 ## [0.0.10] - 2025-08-19
 

--- a/internal/src/init.rs
+++ b/internal/src/init.rs
@@ -296,7 +296,9 @@ fn init_fields(
             #init
 
             #(#cfgs)*
-            #[allow(unused_variables)]
+            // Allow `non_snake_case` since the same warning is going to be reported for the struct
+            // field.
+            #[allow(unused_variables, non_snake_case)]
             let #ident = #guard.let_binding();
         });
 

--- a/internal/src/pin_data.rs
+++ b/internal/src/pin_data.rs
@@ -191,7 +191,10 @@ fn generate_unpin_impl(
     quote! {
         // This struct will be used for the unpin analysis. It is needed, because only structurally
         // pinned fields are relevant whether the struct should implement `Unpin`.
-        #[allow(dead_code)] // The fields below are never used.
+        #[allow(
+            dead_code, // The fields below are never used.
+            non_snake_case // The warning will be emitted on the struct definition.
+        )]
         struct __Unpin #generics_with_pin_lt
         #where_token
             #predicates
@@ -318,7 +321,9 @@ fn generate_projections(
     let docs = format!(" Pin-projections of [`{ident}`]");
     quote! {
         #[doc = #docs]
-        #[allow(dead_code)]
+        // Allow `non_snake_case` since the same warning will be emitted on
+        // the struct definition.
+        #[allow(dead_code, non_snake_case)]
         #[doc(hidden)]
         #vis struct #projection #generics_with_pin_lt
             #whr
@@ -386,6 +391,9 @@ fn generate_the_pin_data(
                 /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
                 ///   memory.
                 #(#cfg_attrs)*
+                // Allow `non_snake_case` since the same warning will be emitted on
+                // the struct definition.
+                #[allow(non_snake_case)]
                 #[inline(always)]
                 #vis unsafe fn #field_name(
                     self,

--- a/tests/nonstandard_style.rs
+++ b/tests/nonstandard_style.rs
@@ -1,0 +1,62 @@
+//! Tests that no extra warnings are emitted for non-snake-case fields when using
+//! `#[pin_data]`, `init!` or `pin_init!`.
+//!
+//! See: https://github.com/Rust-for-Linux/pin-init/issues/125
+
+#![deny(nonstandard_style)]
+#![allow(dead_code)]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
+#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
+
+use pin_init::*;
+
+#[allow(non_snake_case)]
+struct Foo {
+    NON_STANDARD_A: usize,
+    nonStandardB: Bar,
+}
+
+#[allow(non_snake_case)]
+struct Bar {
+    Non_Standard_C: usize,
+}
+
+impl Foo {
+    fn new() -> impl Init<Self> {
+        init!(Self {
+            NON_STANDARD_A: {
+                #[expect(
+                    nonstandard_style,
+                    reason = "User code warnings should not be suppressed"
+                )]
+                (0..2).map(|NonStandardInUserCode| NonStandardInUserCode + 1).sum()
+            },
+            nonStandardB <- init!(Bar { Non_Standard_C: 42 }),
+        })
+    }
+}
+
+// Non-camel-case struct name should not produce warnings.
+#[allow(nonstandard_style)]
+#[pin_data]
+struct non_standard_baz {
+    NON_STANDARD: usize,
+    #[pin]
+    nonStandardPin: usize,
+}
+
+impl non_standard_baz {
+    fn new(a: impl PinInit<usize>) -> impl PinInit<Self> {
+        pin_init!(Self {
+            NON_STANDARD: {
+                #[expect(
+                    nonstandard_style,
+                    reason = "User code warnings should not be suppressed"
+                )]
+                let NON_STANDARD_IN_USER_CODE = 41;
+                NON_STANDARD_IN_USER_CODE + 1
+            },
+            nonStandardPin <- a,
+        })
+    }
+}

--- a/tests/ui/expand/many_generics.expanded.rs
+++ b/tests/ui/expand/many_generics.expanded.rs
@@ -13,7 +13,7 @@ where
     _pin: PhantomPinned,
 }
 /// Pin-projections of [`Foo`]
-#[allow(dead_code)]
+#[allow(dead_code, non_snake_case)]
 #[doc(hidden)]
 struct FooProjection<'__pin, 'a, 'b: 'a, T: Bar<'b> + ?Sized + 'a, const SIZE: usize = 0>
 where
@@ -98,6 +98,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn array(
             self,
@@ -114,6 +115,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn r(
             self,
@@ -130,6 +132,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn _pin(
             self,
@@ -157,7 +160,7 @@ const _: () = {
             }
         }
     }
-    #[allow(dead_code)]
+    #[allow(dead_code, non_snake_case)]
     struct __Unpin<'__pin, 'a, 'b: 'a, T: Bar<'b> + ?Sized + 'a, const SIZE: usize = 0>
     where
         T: Bar<'a, 1>,

--- a/tests/ui/expand/pin-data.expanded.rs
+++ b/tests/ui/expand/pin-data.expanded.rs
@@ -5,7 +5,7 @@ struct Foo {
     _pin: PhantomPinned,
 }
 /// Pin-projections of [`Foo`]
-#[allow(dead_code)]
+#[allow(dead_code, non_snake_case)]
 #[doc(hidden)]
 struct FooProjection<'__pin> {
     array: &'__pin mut [u8; 1024 * 1024],
@@ -62,6 +62,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn array(
             self,
@@ -78,6 +79,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn _pin(
             self,
@@ -97,7 +99,7 @@ const _: () = {
             }
         }
     }
-    #[allow(dead_code)]
+    #[allow(dead_code, non_snake_case)]
     struct __Unpin<'__pin> {
         __phantom_pin: ::pin_init::__internal::PhantomInvariantLifetime<'__pin>,
         __phantom: ::pin_init::__internal::PhantomInvariant<Foo>,

--- a/tests/ui/expand/pinned_drop.expanded.rs
+++ b/tests/ui/expand/pinned_drop.expanded.rs
@@ -5,7 +5,7 @@ struct Foo {
     _pin: PhantomPinned,
 }
 /// Pin-projections of [`Foo`]
-#[allow(dead_code)]
+#[allow(dead_code, non_snake_case)]
 #[doc(hidden)]
 struct FooProjection<'__pin> {
     array: &'__pin mut [u8; 1024 * 1024],
@@ -62,6 +62,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn array(
             self,
@@ -78,6 +79,7 @@ const _: () = {
         /// - `(*slot).#field_name` is properly aligned.
         /// - `(*slot).#field_name` points to uninitialized and exclusively accessed
         ///   memory.
+        #[allow(non_snake_case)]
         #[inline(always)]
         unsafe fn _pin(
             self,
@@ -97,7 +99,7 @@ const _: () = {
             }
         }
     }
-    #[allow(dead_code)]
+    #[allow(dead_code, non_snake_case)]
     struct __Unpin<'__pin> {
         __phantom_pin: ::pin_init::__internal::PhantomInvariantLifetime<'__pin>,
         __phantom: ::pin_init::__internal::PhantomInvariant<Foo>,


### PR DESCRIPTION
Allows `nonstandard_style` lint on accessors/values generated as local variables in `init!`.

Since the same warning will be reported by the compiler on the struct field, having the extra warning for the generated accessor/value is unnecessary and confusing.

Reported-by: Gary Guo <gary@garyguo.net>
Link: https://github.com/Rust-for-Linux/pin-init/issues/125
Closes: https://lore.kernel.org/rust-for-linux/DGTBJBIVFZ2K.2F1ZEFGY0G7NK@garyguo.net/
Fixes: f1b0c3c79a8d ("internal: init: remove #[disable_initialized_field_access]")