### PR TITLE
build.rs: use `option_env!` to register env variable dependency

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
 
     let meta = version_meta().unwrap();
 
-    let use_feature = meta.channel == Channel::Nightly || std::env::var("RUSTC_BOOTSTRAP").is_ok();
+    let use_feature = meta.channel == Channel::Nightly || option_env!("RUSTC_BOOTSTRAP").is_some();
     if use_feature {
         // Use this cfg option to control whether we should enable features that are already stable
         // in some new Rust versions, but are available as unstable features in older Rust versions

--- a/internal/build.rs
+++ b/internal/build.rs
@@ -5,7 +5,7 @@ fn main() {
 
     let meta = version_meta().unwrap();
 
-    let use_feature = meta.channel == Channel::Nightly || std::env::var("RUSTC_BOOTSTRAP").is_ok();
+    let use_feature = meta.channel == Channel::Nightly || option_env!("RUSTC_BOOTSTRAP").is_some();
     if use_feature {
         println!("cargo:rustc-cfg=USE_RUSTC_FEATURES");
     }


### PR DESCRIPTION
Cargo automatically registers environment variable as dependency if `env!` or `option_env!` is used, while `std::env::var` would require a manual `cargo:rerun-if-env-changed` print. Thus switch to use the macro.