### PR TITLE
bump minimum Rust version to 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
           cargo hack \
             --clean-per-run \
             --feature-powerset \
-            --version-range 1.78.. \
+            --version-range 1.82.. \
             --clean-per-version \
             check \
             --locked \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `[pin_]init!` now supports attributes on fields (such as `#[cfg(...)]`).
 - Add a `#[default_error(<type>)]` attribute to `[pin_]init!` to override the
   default error (when no `? Error` is specified).
+- Minimum Rust version is bumped to 1.82.
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pin-init"
 version = "0.0.10"
 edition = "2021"
+rust-version = "1.82"
 
 authors = [
     "Benno Lossin <lossin@kernel.org>",

--- a/examples/big_struct_in_place.rs
+++ b/examples/big_struct_in_place.rs
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
-
 use pin_init::*;
 
 // Struct with size over 1GiB

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -2,8 +2,6 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use core::{
     cell::Cell,

--- a/examples/mutex.rs
+++ b/examples/mutex.rs
@@ -2,8 +2,6 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![allow(clippy::missing_safety_doc)]
 
 use core::{

--- a/examples/pthread_mutex.rs
+++ b/examples/pthread_mutex.rs
@@ -3,8 +3,6 @@
 // inspired by <https://github.com/nbdd0121/pin-init/blob/trunk/examples/pthread_mutex.rs>
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 #[cfg(not(windows))]
 mod pthread_mtx {

--- a/examples/static_init.rs
+++ b/examples/static_init.rs
@@ -2,8 +2,6 @@
 
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![allow(unused_imports)]
 
 use core::{

--- a/internal/src/lib.rs
+++ b/internal/src/lib.rs
@@ -6,7 +6,6 @@
 
 //! `pin-init` proc macros.
 
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 // Documentation is done in the pin-init crate instead.
 #![allow(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,12 +263,6 @@
 //! [`impl Init<T, E>`]: crate::Init
 //! [Rust-for-Linux]: https://rust-for-linux.com/
 
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
-#![cfg_attr(
-    all(any(feature = "alloc", feature = "std"), USE_RUSTC_FEATURES),
-    feature(new_uninit)
-)]
 #![forbid(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]

--- a/tests/alloc_fail.rs
+++ b/tests/alloc_fail.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 #[test]
 #[cfg(feature = "alloc")]

--- a/tests/cfgs.rs
+++ b/tests/cfgs.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
-
 use pin_init::{pin_data, pin_init, PinInit};
 
 #[pin_data]

--- a/tests/const-generic-default.rs
+++ b/tests/const-generic-default.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
-
 use pin_init::*;
 
 #[pin_data]

--- a/tests/default_error.rs
+++ b/tests/default_error.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 
 use pin_init::{init, Init};
 

--- a/tests/init-scope.rs
+++ b/tests/init-scope.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 
 use pin_init::*;
 

--- a/tests/many_generics.rs
+++ b/tests/many_generics.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
 #![allow(dead_code)]
 
 use core::{marker::PhantomPinned, pin::Pin};

--- a/tests/ring_buf.rs
+++ b/tests/ring_buf.rs
@@ -1,6 +1,4 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
 #![cfg_attr(feature = "alloc", feature(allocator_api))]
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-
 #[test]
 #[cfg_attr(not(UI_TESTS), ignore)]
 fn ui_compile_fail() {

--- a/tests/underscore.rs
+++ b/tests/underscore.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
-
 use pin_init::{init, Init};
 
 pub struct Foo {

--- a/tests/zeroing.rs
+++ b/tests/zeroing.rs
@@ -1,6 +1,3 @@
-#![cfg_attr(USE_RUSTC_FEATURES, feature(lint_reasons))]
-#![cfg_attr(USE_RUSTC_FEATURES, feature(raw_ref_op))]
-
 use std::marker::PhantomPinned;
 
 use pin_init::*;


### PR DESCRIPTION
Following the kernel minimum version bump in f32fb9c58a5b ("rust: bump Rust minimum supported version to 1.85.0 (Debian Trixie)"), pin-init can bump its minimum version to 1.85, too.

This removes the `lint_reasons` feature which is stabilized in 1.81 and the `raw_ref_ops` and `new_uninit` features which are stabilized in 1.82.