### PR TITLE
clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,20 +78,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
 name = "pin-init"
 version = "0.0.10"
 dependencies = [
  "libc",
  "macrotest",
- "paste",
  "pin-init-internal",
- "prettyplease",
  "rustc_version",
  "trybuild",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ keywords = ["safe", "pin", "init", "no-std", "rust-patterns"]
 categories = ["no-std", "rust-patterns", "embedded"]
 
 [dependencies]
-paste = "1.0"
 pin-init-internal = { path = "./internal", version = "=0.0.6" }
 
 [features]
@@ -33,8 +32,6 @@ rustc_version = "0.4"
 libc = "0.2"
 trybuild = { version = "1.0", features = ["diff"] }
 macrotest = "1.0"
-# needed for macrotest, have to enable verbatim feature to be able to format `&raw` expressions.
-prettyplease = { version = "0.2.37", features = ["verbatim"] }
 
 [lints.rust]
 stable_features = "allow"


### PR DESCRIPTION
The `paste` dependency is no longer used after `syn` migration. The `prettyplease` is already a dependency via `trybuilld`; the explicit dependency was used to enable the `verbatim` feature when it does not support `&raw` expressions. It is supported natively by `prettyplease` now so the feature (and the explicit dependency) was no longer needed.