### PR TITLE
internal: turn `PhantomPinned` error into warnings

### DIFF
--- a/internal/src/diagnostics.rs
+++ b/internal/src/diagnostics.rs
@@ -3,6 +3,7 @@
 use std::fmt::Display;
 
 use proc_macro2::TokenStream;
+use quote::quote_spanned;
 use syn::{spanned::Spanned, Error};
 
 pub(crate) struct DiagCtxt(TokenStream);
@@ -13,6 +14,19 @@ impl DiagCtxt {
         let error = Error::new(span.span(), msg);
         self.0.extend(error.into_compile_error());
         ErrorGuaranteed(())
+    }
+
+    pub(crate) fn warn(&mut self, span: impl Spanned, msg: impl Display) {
+        // Have the message start on a new line for visual clarity.
+        let msg = format!("\n{}", msg);
+        self.0.extend(quote_spanned!(span.span() =>
+            // Approximate using deprecated warning while `proc_macro_diagnostic` is unstable.
+            const _: () = {
+                #[deprecated = #msg]
+                const fn warn() {}
+                warn();
+            };
+        ));
     }
 
     pub(crate) fn with(

--- a/internal/src/pin_data.rs
+++ b/internal/src/pin_data.rs
@@ -85,7 +85,7 @@ pub(crate) fn pin_data(
 
     for (pinned, field) in &fields {
         if !pinned && is_phantom_pinned(&field.ty) {
-            dcx.error(
+            dcx.warn(
                 field,
                 format!(
                     "The field `{}` of type `PhantomPinned` only has an effect \

--- a/tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs
+++ b/tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs
@@ -1,5 +1,7 @@
+#![deny(warnings)]
+
 use pin_init::*;
-// use std::marker::{self, PhantomPinned};
+use std::marker::{self, PhantomPinned};
 
 #[pin_data]
 struct Foo {

--- a/tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.stderr
+++ b/tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.stderr
@@ -1,23 +1,34 @@
-error: The field `pin1` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
- --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:6:5
-  |
-6 |     pin1: PhantomPinned,
-  |     ^^^^^^^^^^^^^^^^^^^
-
-error: The field `pin2` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
- --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:7:5
-  |
-7 |     pin2: marker::PhantomPinned,
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: The field `pin3` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
+error: use of deprecated function `_::warn`:
+       The field `pin1` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
  --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:8:5
   |
-8 |     pin3: core::marker::PhantomPinned,
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+8 |     pin1: PhantomPinned,
+  |     ^^^^^^^^^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:1:9
+  |
+1 | #![deny(warnings)]
+  |         ^^^^^^^^
+  = note: `#[deny(deprecated)]` implied by `#[deny(warnings)]`
 
-error: The field `pin4` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
+error: use of deprecated function `_::warn`:
+       The field `pin2` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
  --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:9:5
   |
-9 |     pin4: ::core::marker::PhantomPinned,
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+9 |     pin2: marker::PhantomPinned,
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use of deprecated function `_::warn`:
+       The field `pin3` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
+  --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:10:5
+   |
+10 |     pin3: core::marker::PhantomPinned,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: use of deprecated function `_::warn`:
+       The field `pin4` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
+  --> tests/ui/compile-fail/pin_data/no_pin_on_phantompinned.rs:11:5
+   |
+11 |     pin4: ::core::marker::PhantomPinned,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The `PhantomPinned` detection is just a lint, and is emitted as an error because there is no `compile_warning!()` macro, and `proc-macro-diagnostics` is not stable.

Use of `#[deprecated = ""]` attribute to approximate custom proc-macro warnings. A new line is added before message for visual clarity.

An example warning with this trick looks like this:

    warning: use of deprecated function `_::warn`:
             The field `pin` of type `PhantomPinned` only has an effect if it has the `#[pin]` attribute
     --> test.rs:9:5
      |
    9 |     pin: marker::PhantomPinned,
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

Closes #51