### PR TITLE
cleanup workaround for old Rust compiler

### DIFF
--- a/internal/src/init.rs
+++ b/internal/src/init.rs
@@ -172,14 +172,7 @@ pub(crate) fn expand(
             init(slot).map(|__InitOk| ())
         };
         // SAFETY: TODO
-        let init = unsafe { ::pin_init::#init_from_closure::<_, #error>(init) };
-        // FIXME: this let binding is required to avoid a compiler error (cycle when computing the
-        // opaque type returned by this function) before Rust 1.81. Remove after MSRV bump.
-        #[allow(
-            clippy::let_and_return,
-            reason = "some clippy versions warn about the let binding"
-        )]
-        init
+        unsafe { ::pin_init::#init_from_closure::<_, #error>(init) }
     }})
 }
 

--- a/internal/src/pin_data.rs
+++ b/internal/src/pin_data.rs
@@ -247,17 +247,17 @@ fn generate_projections(
     let projection = format_ident!("{ident}Projection");
     let this = format_ident!("this");
 
-    let (fields_decl, fields_proj) = collect_tuple(fields.iter().map(
-        |(
-            pinned,
-            Field {
+    let (fields_decl, fields_proj): (Vec<_>, Vec<_>) = fields
+        .iter()
+        .map(|(pinned, field)| {
+            let Field {
                 vis,
                 ident,
                 ty,
                 attrs,
                 ..
-            },
-        )| {
+            } = field;
+
             let mut no_doc_attrs = attrs.clone();
             no_doc_attrs.retain(|a| !a.path().is_ident("doc"));
             let ident = ident
@@ -287,8 +287,8 @@ fn generate_projections(
                     ),
                 )
             }
-        },
-    ));
+        })
+        .collect();
     let structurally_pinned_fields_docs = fields
         .iter()
         .filter_map(|(pinned, field)| pinned.then_some(field))
@@ -497,15 +497,4 @@ impl VisitMut for SelfReplacer {
     fn visit_item_mut(&mut self, _: &mut Item) {
         // Do not descend into items, since items reset/change what `Self` refers to.
     }
-}
-
-// replace with `.collect()` once MSRV is above 1.79
-fn collect_tuple<A, B>(iter: impl Iterator<Item = (A, B)>) -> (Vec<A>, Vec<B>) {
-    let mut res_a = vec![];
-    let mut res_b = vec![];
-    for (a, b) in iter {
-        res_a.push(a);
-        res_b.push(b);
-    }
-    (res_a, res_b)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1139,14 +1139,7 @@ pub const unsafe fn init_from_closure<T: ?Sized, E>(
 pub const unsafe fn cast_pin_init<T, U, E>(init: impl PinInit<T, E>) -> impl PinInit<U, E> {
     // SAFETY: initialization delegated to a valid initializer. Cast is valid by function safety
     // requirements.
-    let res = unsafe { pin_init_from_closure(|ptr: *mut U| init.__pinned_init(ptr.cast::<T>())) };
-    // FIXME: this let binding is required to avoid a compiler error (cycle when computing the opaque
-    // type returned by this function) before Rust 1.81. Remove after MSRV bump.
-    #[allow(
-        clippy::let_and_return,
-        reason = "some clippy versions warn about the let binding"
-    )]
-    res
+    unsafe { pin_init_from_closure(|ptr: *mut U| init.__pinned_init(ptr.cast::<T>())) }
 }
 
 /// Changes the to be initialized type.
@@ -1158,14 +1151,7 @@ pub const unsafe fn cast_pin_init<T, U, E>(init: impl PinInit<T, E>) -> impl Pin
 pub const unsafe fn cast_init<T, U, E>(init: impl Init<T, E>) -> impl Init<U, E> {
     // SAFETY: initialization delegated to a valid initializer. Cast is valid by function safety
     // requirements.
-    let res = unsafe { init_from_closure(|ptr: *mut U| init.__init(ptr.cast::<T>())) };
-    // FIXME: this let binding is required to avoid a compiler error (cycle when computing the opaque
-    // type returned by this function) before Rust 1.81. Remove after MSRV bump.
-    #[allow(
-        clippy::let_and_return,
-        reason = "some clippy versions warn about the let binding"
-    )]
-    res
+    unsafe { init_from_closure(|ptr: *mut U| init.__init(ptr.cast::<T>())) }
 }
 
 /// An initializer that leaves the memory uninitialized.

--- a/tests/ring_buf.rs
+++ b/tests/ring_buf.rs
@@ -157,7 +157,6 @@ pub struct EvenU64 {
 }
 
 impl EvenU64 {
-    #[allow(clippy::manual_is_multiple_of)]
     pub fn new2(value: u64) -> impl Init<Self, Error> {
         init!(Self {
             info: "Hello world!".to_owned(),
@@ -169,7 +168,6 @@ impl EvenU64 {
         }? Error)
     }
 
-    #[allow(clippy::manual_is_multiple_of)]
     pub fn new(value: u64) -> impl Init<Self, ()> {
         init!(Self {
             info: "Hello world!".to_owned(),

--- a/tests/ui/expand/simple-init.expanded.rs
+++ b/tests/ui/expand/simple-init.expanded.rs
@@ -22,12 +22,6 @@ fn main() {
         | -> ::core::result::Result<(), ::core::convert::Infallible> {
             init(slot).map(|__InitOk| ())
         };
-        let init = unsafe {
-            ::pin_init::init_from_closure::<_, ::core::convert::Infallible>(init)
-        };
-        #[allow(
-            clippy::let_and_return,
-            reason = "some clippy versions warn about the let binding"
-        )] init
+        unsafe { ::pin_init::init_from_closure::<_, ::core::convert::Infallible>(init) }
     };
 }


### PR DESCRIPTION
The workaround mentions it's for Rust versions before 1.81. The minimum is now 1.82, thus clean up.