### PR TITLE
pin-init-internal: LICENSE files for crate

### DIFF
--- a/internal/LICENSE-APACHE
+++ b/internal/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/internal/LICENSE-MIT
+++ b/internal/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/to-kernel.sh
+++ b/to-kernel.sh
@@ -61,13 +61,11 @@ head=$(git rev-parse HEAD)
 git am                                              \
     --signoff                                       \
     --directory="rust/pin-init"                     \
+    --exclude="**/LICENSE*"                         \
     --exclude="rust/pin-init/.mailmap"              \
     --exclude="rust/pin-init/.gitignore"            \
     --exclude="rust/pin-init/to-kernel.sh"          \
     --exclude="rust/pin-init/from-kernel.sh"        \
-    --exclude="rust/pin-init/LICENSE-APACHE"        \
-    --exclude="rust/pin-init/LICENSE-MIT"           \
-    --exclude="rust/pin-init/LICENSES/*"            \
     --exclude="rust/pin-init/CHANGELOG.md"          \
     --exclude="rust/pin-init/flake.nix"             \
     --exclude="rust/pin-init/flake.lock"            \


### PR DESCRIPTION
Add LICENSE-* from the root to ensure the pin-init-internal crate includes the LICENSE files.