### PR TITLE
tests: add additional tests that reflect kernel use cases more

### DIFF
--- a/tests/cfgs.rs
+++ b/tests/cfgs.rs
@@ -20,3 +20,10 @@ impl Struct {
 }
 
 struct Field {}
+
+#[pin_data]
+pub struct Struct2 {
+    // Test for cases where the type is not even defined when cfg is not satisfied.
+    #[cfg(any())]
+    non_exist: NonExistentType,
+}

--- a/tests/unsized.rs
+++ b/tests/unsized.rs
@@ -1,0 +1,12 @@
+use pin_init::*;
+
+use std::sync::atomic::AtomicU32;
+
+// Test that `?Sized` types can work as expected.
+// If macro expansion is not careful it may types into positions that required they're typed.
+#[pin_data]
+#[repr(C)]
+struct ArcInner<T: ?Sized> {
+    refcount: AtomicU32,
+    data: T,
+}


### PR DESCRIPTION
Add some examples that pin-init test suites do not catch when doing feature developments.