### PR TITLE
internal: use `loop {}` to produce never value

### DIFF
--- a/internal/src/init.rs
+++ b/internal/src/init.rs
@@ -389,7 +389,7 @@ fn make_field_check(
             ::core::ptr::write(slot, #path {
                 #(
                     #(#field_attrs)*
-                    #field_name: ::core::panic!(),
+                    #field_name: loop {},
                 )*
                 #zeroing_trailer
             })


### PR DESCRIPTION
In the `init!`/`pin_init!` macros, we rely on a trick that assigns never
(`!`) values to all mentioned fields in never-executed code to let the
compiler check that all fields have been initialized.

Currently we use `::core::panic!()` to produce this value, but before Rust
1.91.0, it creates outlined `panic_cold_explicit` functions which do not
get removed by the optimizer, thus leaving dead code behind in the binary.
This has been fixed by [1], which lands in Rust 1.91.0+, higher than the
kernel minimum version 1.85.0.

This causes ~200 dead `panic_cold_explicit` instances being included in the
binary, with ~90 of them from nova-core's usage of pin-init.

Work around the issue by using `loop {}` which creates the never value
without macro expansion or function call at all. All instances of
`panic_cold_explicit` outside libcore are removed by this change in my
kernel build.