### PR TITLE
docs: link Zeroable::zeroed and pin_init::zeroed in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1557,6 +1557,7 @@ pub unsafe trait Zeroable {
     /// assert_eq!(point.x, 0);
     /// assert_eq!(point.y, 0);
     /// ```
+    #[inline]
     fn zeroed() -> Self
     where
         Self: Sized,
@@ -1603,6 +1604,7 @@ pub fn init_zeroed<T: Zeroable>() -> impl Init<T> {
 /// assert_eq!(point.x, 0);
 /// assert_eq!(point.y, 0);
 /// ```
+#[inline]
 pub const fn zeroed<T: Zeroable>() -> T {
     // SAFETY:By the type invariants of `Zeroable`, all zeroes is a valid bit pattern for `T`.
     unsafe { core::mem::zeroed() }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1539,10 +1539,13 @@ pub unsafe trait Zeroable {
     /// Whenever a type implements [`Zeroable`], this function should be preferred over
     /// [`core::mem::zeroed()`] or using `MaybeUninit<T>::zeroed().assume_init()`.
     ///
+    /// As const traits are not yet stable, [`pin_init::zeroed()`] can be used instead
+    /// when initialization is required in a `const` context.
+    ///
     /// # Examples
     ///
     /// ```
-    /// use pin_init::{Zeroable, zeroed};
+    /// use pin_init::Zeroable;
     ///
     /// #[derive(Zeroable)]
     /// struct Point {
@@ -1550,7 +1553,7 @@ pub unsafe trait Zeroable {
     ///     y: u32,
     /// }
     ///
-    /// let point: Point = zeroed();
+    /// let point: Point = Zeroable::zeroed();
     /// assert_eq!(point.x, 0);
     /// assert_eq!(point.y, 0);
     /// ```
@@ -1581,6 +1584,9 @@ pub fn init_zeroed<T: Zeroable>() -> impl Init<T> {
 ///
 /// Whenever a type implements [`Zeroable`], this function should be preferred over
 /// [`core::mem::zeroed()`] or using `MaybeUninit<T>::zeroed().assume_init()`.
+///
+/// While const traits remain unstable, this function serves as the `const` version of
+/// [`Zeroable::zeroed()`].
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This PR contains two commits.

### docs: link `Zeroable::zeroed` and `pin_init::zeroed` in documentation

Modify the comments in the `pin_init::zeroed` and `Zeroable::zeroed`
functions to cross-reference each other and make developers aware of
both options.

This also adapts the example code in `Zeroable::zeroed` doc comments to
use that function.

### mark pin_init::zeroed and Zeroable::zeroed as #[inline]
The `pin_init::zeroed` function is a trivial wrapper around
`unsafe { core::mem::zeroed() }`, whereas `Zeroable::zeroed` is a
trivial wrapper around `pin_init::zeroed`. Mark them both as `#[inline]`
to avoid generating unnecessary symbols for them.
