### PR TITLE
CI Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - run: sudo apt-get install -y linkchecker
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-rdme
+          tool: cargo-rdme@1.5.1
       - run: git config user.name "github-runner" && git config user.email "<>"
 
       - name: Signed-off-by Tag Check

--- a/tests/symbol_length.rs
+++ b/tests/symbol_length.rs
@@ -57,5 +57,5 @@ fn type_name() {
     let symbol = &symbols[0];
     println!("{}: {}", symbol.len(), symbol);
 
-    assert!(symbol.len() < 180);
+    assert!(symbol.len() < 181);
 }


### PR DESCRIPTION
Two things that break CI:
* Due to `io::Error` being moved from `std` to `core`, the symbol length grow by 1.
* cargo rdme's new pinned nightly requirement